### PR TITLE
Remove mysterious shadow

### DIFF
--- a/FlickSKKKeyboard/KeyButton.swift
+++ b/FlickSKKKeyboard/KeyButton.swift
@@ -82,10 +82,8 @@ class KeyButton: UIView, UIGestureRecognizerDelegate {
             l.textAlignment = .Center
             l.font = UIFont.systemFontOfSize(17.0)
         }
-        self.layer.tap { (l:CALayer) in
-            l.borderColor = UIColor.grayColor().CGColor
-            l.borderWidth = 1.0 / UIScreen.mainScreen().scale / 2.0
-        }
+        self.layer.borderColor = UIColor.grayColor().CGColor
+        self.layer.borderWidth = 1.0 / UIScreen.mainScreen().scale / 2.0
         
         let views = [
             "label": label,


### PR DESCRIPTION
![776ebc3a-f026-45c8-b16b-cf1faa5e41ba_42830f9f33a5db2b155fa9169026bb7f](https://cloud.githubusercontent.com/assets/9650/5156639/46547088-7318-11e4-8c29-d2b09f4abd51.jpg)
## 現象
- ipaを作成すると、`KeyButton` のまわりに謎の影が付く。 (参考: #32)
- `KeyButton#layer` の `borderWidth` が設定されていない
## 対処療法
- `Object#tap` を使わずに設定したら、幅を指定できた。
