### PR TITLE
remove TestFlightSDK and fix builds for empty Podfile

### DIFF
--- a/Common/FlickSKK-Common-Bridging-Header.h
+++ b/Common/FlickSKK-Common-Bridging-Header.h
@@ -4,4 +4,3 @@
 
 #import "IOUtil.h"
 #include "AppGroup.h"
-#import <TestFlight.h>

--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -48,8 +48,6 @@
 		13F9326D19E2DC1700AC5019 /* KeyPad.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA985FE519D84AAE0043564C /* KeyPad.swift */; };
 		13F9326E19E2DC1700AC5019 /* KeyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA985FE719D84D060043564C /* KeyButton.swift */; };
 		13F9326F19E2DC1700AC5019 /* KeyButtonFlickPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2D4D7E19E173EC00607C35 /* KeyButtonFlickPopup.swift */; };
-		BDB55BD40232F36069D06BEA /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CA289C0ED7662F2EF0F3718 /* libPods.a */; };
-		D3C6CB3D1AD977725CC25D71 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CA289C0ED7662F2EF0F3718 /* libPods.a */; };
 		EA075F7F19DED7A4009AEF9F /* KeyboardSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA075F7E19DED7A4009AEF9F /* KeyboardSpacerView.swift */; };
 		EA075F8019DED8C3009AEF9F /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD4B59819D80AF3007B6636 /* Utilities.swift */; };
 		EA28E7F51A21D3B8005DF803 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = EA28E7F41A21D3B8005DF803 /* LaunchScreen.xib */; };
@@ -241,7 +239,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D3C6CB3D1AD977725CC25D71 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -258,7 +255,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BDB55BD40232F36069D06BEA /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -483,12 +479,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAD4B57F19D5CB50007B6636 /* Build configuration list for PBXNativeTarget "FlickSKK" */;
 			buildPhases = (
-				4AD21888C8503609423B858B /* Check Pods Manifest.lock */,
 				EAD4B55C19D5CB50007B6636 /* Sources */,
 				EAD4B55D19D5CB50007B6636 /* Frameworks */,
 				EAD4B55E19D5CB50007B6636 /* Resources */,
 				EAD4B59719D5CB8A007B6636 /* Embed App Extensions */,
-				94C388D56254C67A634D6A69 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -524,11 +518,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAD4B59419D5CB8A007B6636 /* Build configuration list for PBXNativeTarget "FlickSKKKeyboard" */;
 			buildPhases = (
-				615951FED57DDE5CF8812387 /* Check Pods Manifest.lock */,
 				EAD4B58519D5CB8A007B6636 /* Sources */,
 				EAD4B58619D5CB8A007B6636 /* Frameworks */,
 				EAD4B58719D5CB8A007B6636 /* Resources */,
-				D6AE722925FC7A8289638138 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -689,69 +681,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		4AD21888C8503609423B858B /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		615951FED57DDE5CF8812387 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		94C388D56254C67A634D6A69 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D6AE722925FC7A8289638138 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		EAD4B55C19D5CB50007B6636 /* Sources */ = {
@@ -956,7 +885,6 @@
 		};
 		EAD4B58019D5CB50007B6636 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 70E538640700B5CE0D567B64 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = FlickSKK/FlickSKK.entitlements;
@@ -970,7 +898,6 @@
 		};
 		EAD4B58119D5CB50007B6636 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F3DD18F195A212F9D8B92DB9 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = FlickSKK/FlickSKK.entitlements;
@@ -993,15 +920,8 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/TestFlightSDK\"",
-				);
 				INFOPLIST_FILE = FlickSKKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "\"$(PODS_ROOT)/TestFlightSDK\"";
 				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FlickSKK.app/FlickSKK";
@@ -1016,15 +936,8 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/TestFlightSDK\"",
-				);
 				INFOPLIST_FILE = FlickSKKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "\"$(PODS_ROOT)/TestFlightSDK\"";
 				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FlickSKK.app/FlickSKK";
@@ -1033,7 +946,6 @@
 		};
 		EAD4B59519D5CB8A007B6636 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 70E538640700B5CE0D567B64 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FlickSKKKeyboard/FlickSKKKeyboard.entitlements;
@@ -1053,7 +965,6 @@
 		};
 		EAD4B59619D5CB8A007B6636 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F3DD18F195A212F9D8B92DB9 /* Pods.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FlickSKKKeyboard/FlickSKKKeyboard.entitlements;

--- a/FlickSKK/AppDelegate.swift
+++ b/FlickSKK/AppDelegate.swift
@@ -19,8 +19,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = UINavigationController(rootViewController: MainMenuViewController())
         window?.makeKeyAndVisible()
         
-        TestFlight.takeOff("20d9b8e4-ea7b-4f65-a81f-89313f8b4a33")
-        
         return true
     }
 

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
-link_with 'FlickSKKKeyboard'
+# link_with 'FlickSKKKeyboard'
 
-pod 'TestFlightSDK'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,1 @@
-PODS:
-  - TestFlightSDK (3.0.2)
-
-DEPENDENCIES:
-  - TestFlightSDK
-
-SPEC CHECKSUMS:
-  TestFlightSDK: 0c24c533748d0d84bfe7a3cb6036fa79124d84ee
-
 COCOAPODS: 0.34.4


### PR DESCRIPTION
TestFlightSDKはappでしか実質意味がなく，いまのところそこで活用もできないので削ります。
その結果，Podfileが空になったのでビルド通るようにしました。
Podのxcconfigのカスケードも消したので，復活させるときは
pull request #41 from codefirst/configurable-app-identifier も参考。
