### PR TITLE
送り仮名付き単語登録の単語登録を修正

### DIFF
--- a/FlickSKKKeyboard/KeyEvent.swift
+++ b/FlickSKKKeyboard/KeyEvent.swift
@@ -19,6 +19,6 @@ enum KeyEvent {
     case ToggleUpperLower(beforeText : String)
     
     // 仮想イベント
-    case CommitWord(kanji: String)
+    case CommitWord(word: String)
     case CancelWord
 }

--- a/FlickSKKKeyboard/KeyboardViewController.swift
+++ b/FlickSKKKeyboard/KeyboardViewController.swift
@@ -29,7 +29,7 @@ enum KanaFlickKey: Hashable {
     case UpperLower
     case Space
     case Nothing
-    
+
     var buttonLabel: String {
         switch self {
         case let .Seq(s): return String(s[s.startIndex])

--- a/FlickSKKKeyboard/SKKSession.swift
+++ b/FlickSKKKeyboard/SKKSession.swift
@@ -41,9 +41,9 @@ class SKKSession : BaseSession {
     
     private func onWordRegister(event : KeyEvent) {
         switch subSession?.handle(event) {
-        case .Some(.Commit(kanji : let kanji)):
+        case .Some(.Commit(word : let word)):
             self.status = .Default
-            onDefault(.CommitWord(kanji: kanji))
+            onDefault(.CommitWord(word: word))
         case .Some(.Cancel):
             self.status = .Default
             onDefault(.CancelWord)

--- a/FlickSKKKeyboard/WordRegisterSession.swift
+++ b/FlickSKKKeyboard/WordRegisterSession.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class WordRegisterSession : BaseSession {
     enum Handle {
-        case Commit(kanji : String)
+        case Commit(word : String)
         case Cancel
         case ToggleDakuten(beforeText : String)
         case Handles(xs : [InputMode.Handle])
@@ -47,8 +47,10 @@ class WordRegisterSession : BaseSession {
             switch h {
             case .InsertText(text: let text):
                 if(text == "\n") {
-                    self.dictionary.register(self.kana, okuri: self.okuri?.1, kanji: kanji)
-                    return .Commit(kanji: kanji)
+                    let okuri = (self.okuri?.1).map({ s in String(s[s.startIndex])}) 
+                    self.dictionary.register(self.kana, okuri: okuri, kanji: kanji)
+                    let okuriStr = (self.okuri?.0) ?? ""
+                    return .Commit(word: kanji + okuriStr)
                 } else {
                     self.kanji += text
                 }
@@ -89,9 +91,9 @@ class WordRegisterSession : BaseSession {
     
     private func onRegisterWord(event : KeyEvent) -> Handle {
         switch subSession?.handle(event) {
-        case .Some(.Commit(kanji : let kanji)):
+        case .Some(.Commit(word : let word)):
             self.status = .Default
-            return onDefault(.CommitWord(kanji: kanji))
+            return onDefault(.CommitWord(word: word))
         case .Some(.Cancel):
             self.status = .Default
             return onDefault(.CancelWord)

--- a/FlickSKKTests/SKKSessionSpec.swift
+++ b/FlickSKKTests/SKKSessionSpec.swift
@@ -187,6 +187,31 @@ class SKKSessionSpec : QuickSpec, SKKDelegate {
                     session.handle(.ToggleDakuten(beforeText: ""))
                     session.handle(.Enter)
                     expect(self.insertedText).to(equal("が"))
+
+                    self.insertedText = ""
+
+                    session.handle(.Char(kana: "か", roman: "ka", shift: true))
+                    session.handle(.Char(kana: "か", roman: "ka", shift: false))
+                    session.handle(.Char(kana: "か", roman: "ka", shift: false))
+                    session.handle(.Space)
+                    session.handle(.Enter)
+                    expect(self.insertedText).to(equal("が"))
+                }
+                it("can register word with okuri") {
+                    // かかk を辞書に登録する
+                    session.handle(.Char(kana: "か", roman: "ka", shift: true))
+                    session.handle(.Char(kana: "か", roman: "ka", shift: false))
+                    session.handle(.Char(kana: "か", roman: "ka", shift: true))
+                    session.handle(.Char(kana: "か", roman: "ka", shift: false))
+                    session.handle(.Enter)
+                    expect(self.insertedText).to(equal("かか"))
+                    self.insertedText = ""
+
+                    session.handle(.Char(kana: "か", roman: "ka", shift: true))
+                    session.handle(.Char(kana: "か", roman: "ka", shift: false))
+                    session.handle(.Char(kana: "か", roman: "ka", shift: true))
+                    session.handle(.Enter)
+                    expect(self.insertedText).to(equal("かか"))
                 }
             }
         }


### PR DESCRIPTION
- [x] 単語登録した直後、送り仮名が消える不具合を修正
- [x] 送り仮名つきの単語を登録しても、変換できない不具合を修正
