### PR TITLE
FlickSKKにSKK辞書を含めない

### DIFF
--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -51,7 +51,6 @@
 		13F9326E19E2DC1700AC5019 /* KeyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA985FE719D84D060043564C /* KeyButton.swift */; };
 		13F9326F19E2DC1700AC5019 /* KeyButtonFlickPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2D4D7E19E173EC00607C35 /* KeyButtonFlickPopup.swift */; };
 		13FFFD471A3D24F70049D45D /* skk.jisyo in Resources */ = {isa = PBXBuildFile; fileRef = 13D118C719D99923009E9E79 /* skk.jisyo */; };
-		13FFFD511A3D261C0049D45D /* skk.jisyo in Resources */ = {isa = PBXBuildFile; fileRef = 13D118C719D99923009E9E79 /* skk.jisyo */; };
 		EA075F7F19DED7A4009AEF9F /* KeyboardSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA075F7E19DED7A4009AEF9F /* KeyboardSpacerView.swift */; };
 		EA075F8019DED8C3009AEF9F /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD4B59819D80AF3007B6636 /* Utilities.swift */; };
 		EA28E7F51A21D3B8005DF803 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = EA28E7F41A21D3B8005DF803 /* LaunchScreen.xib */; };
@@ -622,7 +621,6 @@
 				EA892D5719FBE70400265181 /* iTunesArtwork in Resources */,
 				EA892D5819FBE70400265181 /* iTunesArtwork@2x in Resources */,
 				EACD529A19F3F0C4001FB2A7 /* Localizable.strings in Resources */,
-				13FFFD511A3D261C0049D45D /* skk.jisyo in Resources */,
 				EAD4B56D19D5CB50007B6636 /* Images.xcassets in Resources */,
 				EA28E7F51A21D3B8005DF803 /* LaunchScreen.xib in Resources */,
 				EACD52A419F3F58B001FB2A7 /* html in Resources */,

--- a/FlickSKKTests/SKKDictionaryLocalFileSpec.swift
+++ b/FlickSKKTests/SKKDictionaryLocalFileSpec.swift
@@ -11,7 +11,8 @@ import Nimble
 
 class SKKDictionaryLocalFileSpec : QuickSpec {
     override func spec() {
-        let jisyo = NSBundle.mainBundle().pathForResource("skk", ofType: "jisyo")
+        let bundle = NSBundle(forClass: self.classForCoder)
+        let jisyo = bundle.pathForResource("skk", ofType: "jisyo")
         let dict = SKKLocalDictionaryFile(path: jisyo!)
         describe("okuri-nasi") {
             it("can find at first entry") {

--- a/FlickSKKTests/SKKSessionSpec.swift
+++ b/FlickSKKTests/SKKSessionSpec.swift
@@ -23,7 +23,8 @@ class SKKSessionSpec : QuickSpec, SKKDelegate {
 
     override func spec() {
         var session : SKKSession!
-        let jisyo = NSBundle.mainBundle().pathForResource("skk", ofType: "jisyo")
+        let bundle = NSBundle(forClass: self.classForCoder)
+        let jisyo = bundle.pathForResource("skk", ofType: "jisyo")
         let dict = SKKDictionary(userDict: "", dicts:[jisyo!])
         dict.waitForLoading()
 


### PR DESCRIPTION
設定アプリのほうのリソースにskk.jisyoを含める必要はないので削除する。
ただ、単純に削除するだけどテストが辞書をロードできなくて死ぬので、ロード部分のみ変更する。

http://stackoverflow.com/questions/1879247/why-cant-code-inside-unit-tests-find-bundle-resources
