### PR TITLE
辞書中の数字用エントリを扱えるようにする

### DIFF
--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -7,8 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		130CA3901A4EF94C00A84D24 /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */; };
+		130CA3961A4EF99800A84D24 /* NumberFormatterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CA3951A4EF99800A84D24 /* NumberFormatterSpec.swift */; };
+		130CA3971A4EFA3F00A84D24 /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */; };
+		130CA3981A4EFA4200A84D24 /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */; };
 		131DBA8F1A42403100756CFA /* WordRegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131DBA8E1A42403100756CFA /* WordRegisterViewController.swift */; };
 		132607DC1A3D65C000DA9F8C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 132607D91A3D658000DA9F8C /* Quick.framework */; };
+		133432C11A4D95030080280F /* SKKNumberPreprocessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133432C01A4D95030080280F /* SKKNumberPreprocessor.swift */; };
+		133432C61A4D9BA90080280F /* SKKNumberPreprocessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133432C01A4D95030080280F /* SKKNumberPreprocessor.swift */; };
+		133432C71A4D9BE90080280F /* SKKNumberPreprocessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133432C01A4D95030080280F /* SKKNumberPreprocessor.swift */; };
 		133CDCF619D98A3C00B8120D /* SKKDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133CDCF519D98A3B00B8120D /* SKKDelegate.swift */; };
 		133CDCF919D98ADA00B8120D /* KeyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133CDCF819D98ADA00B8120D /* KeyEvent.swift */; };
 		133CDCFB19D98DAB00B8120D /* SKKSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133CDCFA19D98DAB00B8120D /* SKKSession.swift */; };
@@ -170,8 +177,11 @@
 
 /* Begin PBXFileReference section */
 		0CA289C0ED7662F2EF0F3718 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormatter.swift; sourceTree = "<group>"; };
+		130CA3951A4EF99800A84D24 /* NumberFormatterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormatterSpec.swift; sourceTree = "<group>"; };
 		131DBA8E1A42403100756CFA /* WordRegisterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordRegisterViewController.swift; sourceTree = "<group>"; };
 		132607C91A3D658000DA9F8C /* Quick.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Quick.xcodeproj; path = Vendor/Quick/Quick.xcodeproj; sourceTree = SOURCE_ROOT; };
+		133432C01A4D95030080280F /* SKKNumberPreprocessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKNumberPreprocessor.swift; sourceTree = "<group>"; };
 		133CDCF519D98A3B00B8120D /* SKKDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDelegate.swift; sourceTree = "<group>"; };
 		133CDCF819D98ADA00B8120D /* KeyEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyEvent.swift; sourceTree = "<group>"; };
 		133CDCFA19D98DAB00B8120D /* SKKSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKSession.swift; sourceTree = "<group>"; };
@@ -273,6 +283,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		1327F7B01A4FB161009796FB /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */,
+				EAD4B59819D80AF3007B6636 /* Utilities.swift */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
 		133CDCF719D98A4C00B8120D /* SKKBase */ = {
 			isa = PBXGroup;
 			children = (
@@ -313,6 +332,7 @@
 				13DFEAC519F07A3C006D7E40 /* SKKUserDictionaryFile.swift */,
 				13DFEAC719F07A54006D7E40 /* SKKLocalDictionaryFile.swift */,
 				13D118CE19D9994D009E9E79 /* SKKDictionary.swift */,
+				133432C01A4D95030080280F /* SKKNumberPreprocessor.swift */,
 			);
 			name = SKKDictionary;
 			sourceTree = "<group>";
@@ -412,6 +432,7 @@
 				13E29D2019E43E9D0097DFCD /* SKKSessionSpec.swift */,
 				1341A24819E96A7F00EE8AFA /* SKKDictionaryLocalFileSpec.swift */,
 				136F409819E9D5ED009E3983 /* SKKDictionaryUserFileSpec.swift */,
+				130CA3951A4EF99800A84D24 /* NumberFormatterSpec.swift */,
 				EAD4B57919D5CB50007B6636 /* Supporting Files */,
 			);
 			path = FlickSKKTests;
@@ -431,13 +452,13 @@
 				133CDCF719D98A4C00B8120D /* SKKBase */,
 				13DFEAC319F079C8006D7E40 /* SKKDictionary */,
 				133CDCFC19D98DB100B8120D /* SKKSession */,
+				1327F7B01A4FB161009796FB /* Utilities */,
 				EAD4B58D19D5CB8A007B6636 /* KeyboardViewController.swift */,
 				136D160E19DA86690091D6BF /* CandidateDataSource.swift */,
 				EA985FE519D84AAE0043564C /* KeyPad.swift */,
 				137AAB441A3C0F3F0092F8A5 /* KeyRepeatTimer.swift */,
 				EA985FE719D84D060043564C /* KeyButton.swift */,
 				EA2D4D7E19E173EC00607C35 /* KeyButtonFlickPopup.swift */,
-				EAD4B59819D80AF3007B6636 /* Utilities.swift */,
 				EA2F67961A21D9C700DDCBB9 /* Resources */,
 				EAD4B58B19D5CB8A007B6636 /* Supporting Files */,
 			);
@@ -665,6 +686,8 @@
 				EACD52B619F3FEFD001FB2A7 /* SKKLocalDictionaryFile.swift in Sources */,
 				EA075F8019DED8C3009AEF9F /* Utilities.swift in Sources */,
 				131DBA8F1A42403100756CFA /* WordRegisterViewController.swift in Sources */,
+				133432C61A4D9BA90080280F /* SKKNumberPreprocessor.swift in Sources */,
+				130CA3981A4EFA4200A84D24 /* NumberFormatter.swift in Sources */,
 				EACD52B719F3FF0F001FB2A7 /* IOUtil.mm in Sources */,
 				EACD52A119F3F2EC001FB2A7 /* WebViewController.swift in Sources */,
 				EACD52B519F3FEF1001FB2A7 /* SKKDictionaryFile.swift in Sources */,
@@ -686,6 +709,9 @@
 				137AAB4E1A3C13970092F8A5 /* KeyRepeatTimer.swift in Sources */,
 				1341A24919E96A7F00EE8AFA /* SKKDictionaryLocalFileSpec.swift in Sources */,
 				13F9326619E2DC1700AC5019 /* IOUtil.mm in Sources */,
+				130CA3961A4EF99800A84D24 /* NumberFormatterSpec.swift in Sources */,
+				133432C71A4D9BE90080280F /* SKKNumberPreprocessor.swift in Sources */,
+				130CA3971A4EFA3F00A84D24 /* NumberFormatter.swift in Sources */,
 				13F9326719E2DC1700AC5019 /* InputMode.swift in Sources */,
 				13F9326819E2DC1700AC5019 /* WordRegisterSession.swift in Sources */,
 				13F9326919E2DC1700AC5019 /* SKKSession.swift in Sources */,
@@ -723,8 +749,10 @@
 				EA2D4D7F19E173EC00607C35 /* KeyButtonFlickPopup.swift in Sources */,
 				13F4525419DC5399001A4A1B /* IOUtil.mm in Sources */,
 				136D160F19DA86690091D6BF /* CandidateDataSource.swift in Sources */,
+				133432C11A4D95030080280F /* SKKNumberPreprocessor.swift in Sources */,
 				133CDCFB19D98DAB00B8120D /* SKKSession.swift in Sources */,
 				1388669A1A09202500B7D8A4 /* SKKDictionaryEntry.swift in Sources */,
+				130CA3901A4EF94C00A84D24 /* NumberFormatter.swift in Sources */,
 				133CDCF619D98A3C00B8120D /* SKKDelegate.swift in Sources */,
 				13DFEAC619F07A3C006D7E40 /* SKKUserDictionaryFile.swift in Sources */,
 				EA985FE819D84D060043564C /* KeyButton.swift in Sources */,

--- a/FlickSKKKeyboard/NumberFormatter.swift
+++ b/FlickSKKKeyboard/NumberFormatter.swift
@@ -1,0 +1,84 @@
+//
+//  NumberFormatter.swift
+//  FlickSKK
+//
+//  Created by MIZUNO Hiroki on 12/27/14.
+//  Copyright (c) 2014 BAN Jun. All rights reserved.
+//
+
+class NumberFormatter {
+    let value : Int
+    init(value : Int) {
+        self.value = value
+    }
+
+    func asAscii() -> String {
+        return NSString(format: "%d", self.value)
+    }
+
+    func asFullWidth() -> String {
+        return conv(asAscii(), from: "0123456789", to: "０１２３４５６７８９")
+    }
+
+    func asJapanese() -> String {
+        return conv(asAscii(), from: "0123456789", to: "〇一二三四五六七八九")
+    }
+
+    func asKanji() -> String {
+        if value == 0 {
+            return "零"
+        } else {
+            return toKanji(value)
+        }
+    }
+
+    private func conv(target : String, from : String, to : String) -> String {
+        return implode(Array(target).map( { c in
+            tr(c, from, to) ?? c
+        }))
+    }
+
+
+    private func toKanji_lt_10(n : Int) -> String? {
+        // where n < 10
+        if n == 0 {
+            return .None
+        } else if n == 1 {
+            return ""
+        } else {
+            let xs = Array("__二三四五六七八九")
+            return String(xs[n])
+        }
+    }
+
+    private func toKanjiDigit(n : Int, at : Int, name: String) -> String {
+        return toKanji_lt_10((n / at) % 10).map({ c in c + name }) ?? ""
+    }
+
+    private func toKanji_lt_10000(n : Int) -> String? { // where n < 10_000
+        if n == 0 {
+            return .None
+        } else if n == 1 {
+            return "一"
+        } else {
+            let _1000 = toKanjiDigit(n, at: 1000, name: "千")
+            let _100 = toKanjiDigit(n, at: 100, name: "百")
+            let _10 = toKanjiDigit(n, at: 10, name: "十")
+            let _1 = toKanjiDigit(n, at: 1, name: "")
+            return _1000 + _100 + _10 + _1
+        }
+    }
+
+    private func toKanjiDigits(n : Int, at : Int, name: String) -> String {
+        return toKanji_lt_10000((n / at) % 1_0000).map({ c in c + name }) ?? ""
+    }
+
+    private func toKanji(n : Int) -> String {
+        let 兆 = toKanjiDigits(n, at: 1_0000_0000_0000, name: "兆")
+        let 億 = toKanjiDigits(n, at: 1_0000_0000, name: "億")
+        let 万 = toKanjiDigits(n, at: 1_0000, name: "万")
+        let rest = toKanjiDigits(n, at: 1, name: "")
+
+        return 兆 + 億 + 万 + rest
+    }
+}

--- a/FlickSKKKeyboard/SKKLocalDictionaryFile.swift
+++ b/FlickSKKKeyboard/SKKLocalDictionaryFile.swift
@@ -40,18 +40,29 @@ class SKKLocalDictionaryFile : SKKDictionaryFile {
     func find(normal : String, okuri : String?) -> [ String ] {
         switch okuri {
         case .None:
-            let str = binarySearch(normal + " ",
+            return search(normal + " ",
                 xs: self.okuriNasi,
-                begin: 0, end: self.okuriNasi.count,
-                compare: NSComparisonResult.OrderedAscending) ?? ""
-            return parse(str)
+                compare: NSComparisonResult.OrderedAscending)
         case .Some(let okuri):
-            let str = binarySearch(normal + okuri + " ",
+            return search(normal + okuri + " ",
                 xs: self.okuriAri,
-                begin: 0, end: self.okuriAri.count,
-                compare: NSComparisonResult.OrderedDescending) ?? ""
-            return parse(str)
+                compare: NSComparisonResult.OrderedDescending)
         }
+    }
+
+    private func search(target : NSString, xs : NSMutableArray, compare : NSComparisonResult) -> [String] {
+        let preprocessor = SKKNumberPreprocessor(value: target)
+
+        let line = binarySearch(preprocessor.preProcess(),
+            xs: xs,
+            begin: 0,
+            end: xs.count,
+            compare: compare) ?? ""
+
+        let entries = parse(line)
+
+        return entries.map({ entry in
+            return preprocessor.postProcess(entry) })
     }
 
     private func binarySearch(target : NSString, xs : NSMutableArray, begin : Int, end : Int, compare : NSComparisonResult) -> String? {

--- a/FlickSKKKeyboard/SKKNumberPreprocessor.swift
+++ b/FlickSKKKeyboard/SKKNumberPreprocessor.swift
@@ -1,0 +1,79 @@
+//
+//  SKKNumberPreprocess.swift
+//  FlickSKK
+//
+//  Created by MIZUNO Hiroki on 12/26/14.
+//  Copyright (c) 2014 BAN Jun. All rights reserved.
+//
+
+class SKKNumberPreprocessor {
+    private let value : String
+    private var numbers : [Int] = []
+
+    private let regexp : NSRegularExpression! =
+        NSRegularExpression(pattern: "[0-9]+", options: nil, error: nil)
+
+    private let template : NSRegularExpression! =
+        NSRegularExpression(pattern: "#[0-9]", options: nil, error: nil)
+
+    init(value : String) {
+        self.value = value
+    }
+
+    func preProcess() -> String {
+        self.numbers = self.findNumbers(value)
+        return regexp.stringByReplacingMatchesInString(value,
+            options: nil,
+            range: NSMakeRange(0, value.utf16Count),
+            withTemplate: "#")
+    }
+
+    func postProcess(entry : NSString) -> String {
+        var result : NSMutableString =
+            entry.mutableCopy() as NSMutableString
+
+        var ret =
+            template.firstMatchInString(result, options: nil, range: NSMakeRange(0, result.length))
+
+        var index = 0
+
+        while let x = ret {
+            let matched = result.substringWithRange(x.range)
+
+            template.replaceMatchesInString(result,
+                options: nil,
+                range: x.range,
+                withTemplate: stringFor(numbers[index], entry: matched))
+            index += 1
+            ret = template.firstMatchInString(result, options: nil, range: NSMakeRange(0, result.length))
+        }
+
+        return result
+    }
+
+    private func stringFor(n : Int, entry : String) -> String {
+        let formatter = NumberFormatter(value: n)
+        switch entry {
+        case "#0":
+            return formatter.asAscii()
+        case "#1":
+            return formatter.asFullWidth()
+        case "#2":
+            return formatter.asJapanese()
+        case "#3":
+            return formatter.asKanji()
+        default:
+            return entry
+        }
+    }
+
+    private func findNumbers(value : String) -> [Int] {
+        let xs = regexp.matchesInString(value,
+            options: nil,
+            range: NSMakeRange(0, value.utf16Count)) as [NSTextCheckingResult]
+        return xs.map({ x in
+            let n : NSString = (self.value as NSString).substringWithRange(x.range)
+            return n.integerValue
+        })
+    }
+}

--- a/FlickSKKTests/NumberFormatterSpec.swift
+++ b/FlickSKKTests/NumberFormatterSpec.swift
@@ -1,0 +1,40 @@
+//
+//  NumberFormatterSpec.swift
+//  FlickSKK
+//
+//  Created by MIZUNO Hiroki on 12/27/14.
+//  Copyright (c) 2014 BAN Jun. All rights reserved.
+//
+
+import Quick
+import Nimble
+
+class NumberFormatterSpec : QuickSpec {
+    override func spec() {
+        describe("stringfy") {
+            it("stringfy int") {
+                expect(NumberFormatter(value: 0).asAscii()).to(equal("0"))
+                expect(NumberFormatter(value: 42).asAscii()).to(equal("42"))
+            }
+
+            it("stringfy as Full width") {
+                expect(NumberFormatter(value: 0).asFullWidth()).to(equal("０"))
+                expect(NumberFormatter(value: 42).asFullWidth()).to(equal("４２"))
+            }
+
+            it("stringfy as Japanese") {
+                expect(NumberFormatter(value: 0).asJapanese()).to(equal("〇"))
+                expect(NumberFormatter(value: 42).asJapanese()).to(equal("四二"))
+            }
+
+
+            it("stringfy as Kanji") {
+                expect(NumberFormatter(value: 0).asKanji()).to(equal("零"))
+                expect(NumberFormatter(value: 42).asKanji()).to(equal("四十二"))
+                expect(NumberFormatter(value: 1024).asKanji()).to(equal("千二十四"))
+                expect(NumberFormatter(value: 30000).asKanji()).to(equal("三万"))
+                expect(NumberFormatter(value: 100000001).asKanji()).to(equal("一億一"))
+            }
+        }
+    }
+}

--- a/FlickSKKTests/SKKDictionaryLocalFileSpec.swift
+++ b/FlickSKKTests/SKKDictionaryLocalFileSpec.swift
@@ -29,6 +29,11 @@ class SKKDictionaryLocalFileSpec : QuickSpec {
                 let xs = dict.find("じ", okuri: .None)
                 expect(xs).to(contain("字"))
             }
+            it("can find number entry") {
+                let xs = dict.find("1えん", okuri: .None)
+                expect(xs).to(contain("一円"))
+                expect(xs).to(contain("1円"))
+            }
         }
         describe("okuri-ari") {
             it("can find first entry"){


### PR DESCRIPTION
#24 の関連?
## エントリの例

```
#や /#3夜/#1夜/#0夜/#2夜/
```
## 解説(ドキュメントより抜粋)

 DDSKK は、数字を含む見出し語を様々な候補に変換することができます。 例えば、見出し語「だい12かい」を変換すると 「第１２回」、「第一二回」、「第十二回」といった候補を挙げます。

この節では、このような候補を辞書に登録する方法を説明します。基本は、 数字の部分を `#` で置き替えることです。辞書 `SKK-JISYO.L' のエ ントリーから具体例を見てみましょう。

```
だい#かい /第#1回/第#0回/第#2回/第#3回/第 #0 回/
```

`だい12かい` のような数字を含む見出し語を変換した場合、見出し 語の中の数字の部分は自動的に `#` に置き換えられますの で、辞書エントリーの左辺（つまり見出し語） `だい#かい` にマッチします。 
## タイプ

```

`#0'

    タイプ 0。無変換。入力されたアスキー文字をそのまま出力します。例えば、 `第12回' のような変換を得るために使います。

`#1'

    タイプ 1。全角文字の数字。`12' を `１２' に変換します。

`#2'

    タイプ 2。漢数字で位取りあり。`1024' を `一〇二四' に変換しま す。

`#3'

    タイプ 3。漢数字で位取りなし。`1024' を `千二十四' に変換しま す。

`#4'

    タイプ 4。数値再変換。見出し語中の数字そのもの (50)をキーとして辞書を再検索し、 `#4' の部分を再検索の結果の文字列で入れ替えます。これについては後で 例を挙げて説明します。

`#5'

    タイプ 5。小切手や手形の金額記入の際用いられる表記で変換します。例えば、 `1995' を `壱阡九百九拾伍' に変換します。(これを大字と言います。)

`#8'

    タイプ 8。桁区切り。`1234567' を `1,234,567' に変換します。

`#9'

    タイプ 9。将棋の棋譜の入力用。`全角数字 + 漢数字' に変換します。こ れについては後で例を挙げて説明します。 
```
## どこまで対応するか

L辞書をしらべたところ、ほぼすべてがタイプ3以下。
それ以外は1エントリもしくは0エントリのみ。

なので、タイプ3までの対応とする。
## 参考文章
- http://openlab.ring.gr.jp/skk/skk-manual/skk-manual-ja_5.html#SEC72
