### PR TITLE
特定の手順で操作時にoopsが発生

### DIFF
--- a/FlickSKKKeyboard/BaseSession.swift
+++ b/FlickSKKKeyboard/BaseSession.swift
@@ -19,7 +19,7 @@ class BaseSession {
     var status : Status = .Default
 
     // 通常モード用
-    private let inputMode : [SKKInputMode:InputMode]
+    private let inputMode : InputMode
     var currentMode : SKKInputMode = .Hirakana
     let dictionary : SKKDictionary
 
@@ -28,15 +28,11 @@ class BaseSession {
 
     init(dict : SKKDictionary) {
         self.dictionary = dict
-        self.inputMode = [
-            .Hirakana:    InputMode(sourceType: .Hirakana,    dictionary: self.dictionary),
-            .Katakana:    InputMode(sourceType: .Katakana,    dictionary: self.dictionary),
-            .HankakuKana: InputMode(sourceType: .HankakuKana, dictionary: self.dictionary)
-        ]
+        self.inputMode = InputMode(dictionary: self.dictionary)
     }
 
     func currentInputMode() -> InputMode? {
-        return self.inputMode[self.currentMode]
+        return self.inputMode
     }
 
     func info() -> InputMode.Info? {

--- a/FlickSKKKeyboard/InputMode.swift
+++ b/FlickSKKKeyboard/InputMode.swift
@@ -35,7 +35,7 @@ class InputMode {
     }
 
     // 状態遷移の管理
-    private let sourceType : KanaType
+    private var sourceType : KanaType = .Hirakana
     private let dictionary : SKKDictionary
     private var status     : InputModeStatus = .Default
 
@@ -52,8 +52,7 @@ class InputMode {
     // WordRegister用
     private var oldStatus : InputModeStatus = .Default
 
-    init(sourceType : KanaType, dictionary : SKKDictionary){
-        self.sourceType = sourceType
+    init(dictionary : SKKDictionary) {
         self.dictionary = dictionary
     }
 
@@ -136,6 +135,14 @@ class InputMode {
         case .Backspace:
             return deleteText(1)
         case .InputModeChange(inputMode: let mode):
+            switch mode {
+            case .Hirakana:
+                self.sourceType = .Hirakana
+            case .Katakana:
+                self.sourceType = .Katakana
+            case .HankakuKana:
+                self.sourceType = .HankakuKana
+            }
             return [.InputModeChange(mode: mode)]
         case .ToggleDakuten(beforeText : let beforeText):
             return [.ToggleDakuten(beforeText: beforeText)]


### PR DESCRIPTION
以下の手順で操作した場合にエラーとなりました。

環境
 FlickSKK ver1.0.0 〜
 iOS 8.1.2（iPhone 5s）

---
1. 単語登録モードに入る
   ![evernote camera roll 20141229 145218](https://cloud.githubusercontent.com/assets/10345570/5575618/be150176-9025-11e4-85b9-d735cf279d9a.png)
2. 「カナ」入力に変更する
   ![evernote camera roll 20141229 145312](https://cloud.githubusercontent.com/assets/10345570/5575621/be565586-9025-11e4-8d3d-cbcd6c45efab.png)
3. Deleteを押す
   ![evernote camera roll 20141229 145326](https://cloud.githubusercontent.com/assets/10345570/5575620/be534fc6-9025-11e4-9c1a-d234bb5e346f.png)
4. 「かな」に戻す
   ![evernote camera roll 20141229 145337](https://cloud.githubusercontent.com/assets/10345570/5575619/be5067c0-9025-11e4-879a-1738916ce048.png)
