### PR TITLE
▽モードでもスペースキーのかわりに「次候補」を出すようにした

### DIFF
--- a/FlickSKKKeyboard/ComposeModePresenter.swift
+++ b/FlickSKKKeyboard/ComposeModePresenter.swift
@@ -35,8 +35,8 @@ class ComposeModePresenter {
         switch composeMode {
         case .DirectInput:
             return false
-        case .KanaCompose(kana: let kana):
-            return false
+        case .KanaCompose(_):
+            return true
         case .KanjiCompose(kana: _, okuri: _, candidates: let candidates, index: let index):
             return true
         case .WordRegister(kana : _, okuri : _, composeText : _, composeMode : let m):

--- a/FlickSKKTests/ComposeModePresenterSpec.swift
+++ b/FlickSKKTests/ComposeModePresenterSpec.swift
@@ -52,10 +52,6 @@ class ComposeModePresenterSpec : QuickSpec {
                 let m = ComposeMode.WordRegister(kana: "ほんき", okuri: nil, composeText: "あああ", composeMode: [.DirectInput])
                 expect(target.candidates(m)).to(beNil())
             }
-            it("word register mode(direct)") {
-                let m = ComposeMode.WordRegister(kana: "ろうたけ", okuri: "る", composeText: "あああ", composeMode: [.DirectInput])
-                expect(target.toString(m)).to(equal("[登録:ろうたけ*る]あああ"))
-            }
             it("word register mode(kana compose)") {
                 let m = ComposeMode.WordRegister(kana: "ほんき", okuri: nil, composeText: "あ", composeMode: [
                     .KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["foo", "bar"], index: 1)
@@ -63,6 +59,34 @@ class ComposeModePresenterSpec : QuickSpec {
                 let (candidates, index) = target.candidates(m) ?? ([],0)
                 expect(candidates).to(equal(["foo", "bar"]))
                 expect(index).to(equal(1))
+            }
+        }
+
+
+        describe("inStatusShowsCandidatesBySpace") {
+            it("direct input") {
+                expect(target.inStatusShowsCandidatesBySpace(.DirectInput)).to(beFalse())
+            }
+            it("kana compose mode") {
+                let ret = target.inStatusShowsCandidatesBySpace(.KanaCompose(kana: "こんにちは", candidates: ["foo", "bar"]))
+                expect(ret).to(beTrue())
+            }
+            it("kanji compose mode") {
+                let m = ComposeMode.KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["foo", "bar"], index: 1)
+                let ret = target.inStatusShowsCandidatesBySpace(m)
+                expect(ret).to(beTrue())
+            }
+            it("word register mode(direct)") {
+                let m = ComposeMode.WordRegister(kana: "ほんき", okuri: nil, composeText: "あああ", composeMode: [.DirectInput])
+                let ret = target.inStatusShowsCandidatesBySpace(m)
+                expect(ret).to(beFalse())
+            }
+            it("word register mode(kana compose)") {
+                let m = ComposeMode.WordRegister(kana: "ほんき", okuri: nil, composeText: "あ", composeMode: [
+                    .KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["foo", "bar"], index: 1)
+                    ])
+                let ret = target.inStatusShowsCandidatesBySpace(m)
+                expect(ret).to(beTrue())
             }
         }
     }


### PR DESCRIPTION
>  banjun commented 2 hours ago
> これアグレッシブ候補表示 #18 の初期状態(候補選択されていない状態)でも表示してほしいです。
> https://github.com/codefirst/FlickSKK/issues/61#issuecomment-74375144

の対応です。

![screen shot 2015-02-15 at 12 05 39 am](https://cloud.githubusercontent.com/assets/9650/6200011/c4702988-b4a6-11e4-9e45-2c6f05d7e40f.png)

