### PR TITLE
送りかなありの単語が登録できない不具合を修正

### DIFF
--- a/FlickSKKKeyboard/KeyHandler.swift
+++ b/FlickSKKKeyboard/KeyHandler.swift
@@ -218,11 +218,14 @@ class KeyHandler {
         kana : String, okuri: String?, composeText: String, composeMode: ComposeMode,
         level : Level) -> ComposeMode {
        if (composeMode == ComposeMode.DirectInput) && (keyEvent == SKKKeyEvent.Enter) {
+           // 送り仮名はローマ字に変換する
+           let okuriRoman = okuri?.first()?.toRoman()?.first().map({c in String(c)})
+
            // 辞書登録
-           dictionary.register(kana, okuri: okuri, kanji: composeText)
+           dictionary.register(kana, okuri: okuriRoman, kanji: composeText)
 
            // composeTextを入力する
-           insertText(composeText, level: level)
+           insertText(composeText + (okuri ?? ""), level: level)
 
            // 状態遷移
            return .DirectInput

--- a/FlickSKKTests/KeyHandlerSpec.swift
+++ b/FlickSKKTests/KeyHandlerSpec.swift
@@ -320,12 +320,21 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
                     fail()
                 }
             }
-            it("Enter") {
-                let m = handler.handle(.Enter, composeMode:
-                    .WordRegister(kana: "まじ", okuri: .None, composeText : "本気", composeMode: [ .DirectInput ]))
-                expect(m == .DirectInput).to(beTrue())
-                expect(self.insertedText).to(equal("本気"))
-                expect(dict.find("まじ", okuri: .None)).to(contain("本気"))
+            describe("Enter") {
+                it("送りなし") {
+                    let m = handler.handle(.Enter, composeMode:
+                        .WordRegister(kana: "まじ", okuri: .None, composeText : "本気", composeMode: [ .DirectInput ]))
+                    expect(m == .DirectInput).to(beTrue())
+                    expect(self.insertedText).to(equal("本気"))
+                    expect(dict.find("まじ", okuri: .None)).to(contain("本気"))
+                }
+                it("送りあり") {
+                    let m = handler.handle(.Enter, composeMode:
+                        .WordRegister(kana: "ろうた", okuri: "け", composeText : "臘長", composeMode: [ .DirectInput ]))
+                    expect(m == .DirectInput).to(beTrue())
+                    expect(self.insertedText).to(equal("臘長け"))
+                    expect(dict.find("ろうた", okuri: "k")).to(contain("臘長"))
+                }
             }
             describe("Backspace") {
                 it("index == 0") {


### PR DESCRIPTION
辞書登録するときに送り仮名をアルファベットに変換するのを忘れてた。