### PR TITLE
変換を学習する

### DIFF
--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -50,6 +50,12 @@
 		13DFEAC819F07A54006D7E40 /* SKKLocalDictionaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DFEAC719F07A54006D7E40 /* SKKLocalDictionaryFile.swift */; };
 		13DFEAC919F07AC6006D7E40 /* SKKUserDictionaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DFEAC519F07A3C006D7E40 /* SKKUserDictionaryFile.swift */; };
 		13DFEACA19F07AC8006D7E40 /* SKKLocalDictionaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DFEAC719F07A54006D7E40 /* SKKLocalDictionaryFile.swift */; };
+		13E33E7E1A9E855500CD1140 /* DictionaryEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E7D1A9E855500CD1140 /* DictionaryEngine.swift */; };
+		13E33E7F1A9E855500CD1140 /* DictionaryEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E7D1A9E855500CD1140 /* DictionaryEngine.swift */; };
+		13E33E851A9E87CA00CD1140 /* TextEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E841A9E87CA00CD1140 /* TextEngine.swift */; };
+		13E33E861A9E87CA00CD1140 /* TextEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E841A9E87CA00CD1140 /* TextEngine.swift */; };
+		13E33E881A9E8E3D00CD1140 /* ComposeModeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */; };
+		13E33E891A9E8E3D00CD1140 /* ComposeModeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */; };
 		13F4525419DC5399001A4A1B /* IOUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13F4525319DC5399001A4A1B /* IOUtil.mm */; };
 		13F9325819E2DBFC00AC5019 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD4B59819D80AF3007B6636 /* Utilities.swift */; };
 		13F9326119E2DC1700AC5019 /* SKKDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133CDCF519D98A3B00B8120D /* SKKDelegate.swift */; };
@@ -212,6 +218,9 @@
 		13DFEAB919F079C5006D7E40 /* SKKDictionaryFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionaryFile.swift; sourceTree = "<group>"; };
 		13DFEAC519F07A3C006D7E40 /* SKKUserDictionaryFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKUserDictionaryFile.swift; sourceTree = "<group>"; };
 		13DFEAC719F07A54006D7E40 /* SKKLocalDictionaryFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKLocalDictionaryFile.swift; sourceTree = "<group>"; };
+		13E33E7D1A9E855500CD1140 /* DictionaryEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryEngine.swift; sourceTree = "<group>"; };
+		13E33E841A9E87CA00CD1140 /* TextEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextEngine.swift; sourceTree = "<group>"; };
+		13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeModeFactory.swift; sourceTree = "<group>"; };
 		13F4525119DC538B001A4A1B /* IOUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IOUtil.h; sourceTree = "<group>"; };
 		13F4525319DC5399001A4A1B /* IOUtil.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IOUtil.mm; sourceTree = "<group>"; };
 		70E538640700B5CE0D567B64 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
@@ -362,8 +371,11 @@
 			children = (
 				138968CD1A85E2F400614511 /* SKKEngine.swift */,
 				138968D01A85ED7300614511 /* ComposeMode.swift */,
+				13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */,
 				1306495A1A871FEE0044B225 /* KeyHandler.swift */,
+				13E33E841A9E87CA00CD1140 /* TextEngine.swift */,
 				135A44B91A881F070089F84E /* ComposeModePresenter.swift */,
+				13E33E7D1A9E855500CD1140 /* DictionaryEngine.swift */,
 			);
 			name = SKKEngine;
 			sourceTree = "<group>";
@@ -827,7 +839,9 @@
 				138968DB1A85F42500614511 /* SKKEngine.swift in Sources */,
 				13F9326419E2DC1700AC5019 /* SKKInputMode.swift in Sources */,
 				1306495E1A8723150044B225 /* KeyHandler.swift in Sources */,
+				13E33E881A9E8E3D00CD1140 /* ComposeModeFactory.swift in Sources */,
 				1388669C1A0920D500B7D8A4 /* SKKDictionaryEntry.swift in Sources */,
+				13E33E7E1A9E855500CD1140 /* DictionaryEngine.swift in Sources */,
 				13DFEAC419F07A1F006D7E40 /* SKKDictionaryFile.swift in Sources */,
 				138968DD1A87139600614511 /* KeyHandlerSpec.swift in Sources */,
 				138EB8601A9035D300CB16BC /* Appearance.swift in Sources */,
@@ -841,6 +855,7 @@
 				13F9326B19E2DC1700AC5019 /* KeyboardViewController.swift in Sources */,
 				13F9326D19E2DC1700AC5019 /* KeyPad.swift in Sources */,
 				13DFEAC919F07AC6006D7E40 /* SKKUserDictionaryFile.swift in Sources */,
+				13E33E851A9E87CA00CD1140 /* TextEngine.swift in Sources */,
 				13F9326E19E2DC1700AC5019 /* KeyButton.swift in Sources */,
 				13DFEACA19F07AC8006D7E40 /* SKKLocalDictionaryFile.swift in Sources */,
 				13F9326F19E2DC1700AC5019 /* KeyButtonFlickPopup.swift in Sources */,
@@ -860,15 +875,18 @@
 				EAD4B59919D80AF3007B6636 /* Utilities.swift in Sources */,
 				137AAB451A3C0F3F0092F8A5 /* KeyRepeatTimer.swift in Sources */,
 				13DFEAC819F07A54006D7E40 /* SKKLocalDictionaryFile.swift in Sources */,
+				13E33E891A9E8E3D00CD1140 /* ComposeModeFactory.swift in Sources */,
 				13DFEABA19F079C5006D7E40 /* SKKDictionaryFile.swift in Sources */,
 				13D118D019D9994D009E9E79 /* SKKDictionary.swift in Sources */,
 				EAF1DB7019FBFDFD00816CF5 /* AppGroup.m in Sources */,
 				EA985FE619D84AAE0043564C /* KeyPad.swift in Sources */,
+				13E33E861A9E87CA00CD1140 /* TextEngine.swift in Sources */,
 				EAB03E3C1A765DAF00F3F28F /* SessionView.swift in Sources */,
 				EAD4B58E19D5CB8A007B6636 /* KeyboardViewController.swift in Sources */,
 				1306495B1A871FEE0044B225 /* KeyHandler.swift in Sources */,
 				136D161119DAA0AE0091D6BF /* SKKInputMode.swift in Sources */,
 				138968CE1A85E2F400614511 /* SKKEngine.swift in Sources */,
+				13E33E7F1A9E855500CD1140 /* DictionaryEngine.swift in Sources */,
 				EA2D4D7F19E173EC00607C35 /* KeyButtonFlickPopup.swift in Sources */,
 				1306495D1A8721180044B225 /* SKKKeyEvent.swift in Sources */,
 				13F4525419DC5399001A4A1B /* IOUtil.mm in Sources */,

--- a/FlickSKK.xcodeproj/xcshareddata/xcschemes/FlickSKKKeyboard.xcscheme
+++ b/FlickSKK.xcodeproj/xcshareddata/xcschemes/FlickSKKKeyboard.xcscheme
@@ -2,7 +2,7 @@
 <Scheme
    LastUpgradeVersion = "0600"
    wasCreatedForAppExtension = "YES"
-   version = "1.8">
+   version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -68,15 +68,16 @@
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
-      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES"
       language = "ja"
-      region = "JP">
-      <BuildableProductRunnable>
+      region = "JP"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EAD4B55F19D5CB50007B6636"
@@ -98,8 +99,9 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES"
-      askForAppToLaunch = "Yes">
-      <BuildableProductRunnable>
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EAD4B55F19D5CB50007B6636"

--- a/FlickSKKKeyboard/ComposeModeFactory.swift
+++ b/FlickSKKKeyboard/ComposeModeFactory.swift
@@ -1,0 +1,20 @@
+class ComposeModeFactory {
+    private let dictionary : DictionaryEngine
+
+    init(dictionary : DictionaryEngine) {
+        self.dictionary = dictionary
+    }
+
+    func kanaCompose(kana : String) -> ComposeMode {
+        return .KanaCompose(kana : kana, candidates: dictionary.find(kana, okuri: nil))
+    }
+
+    func kanjiCompose(kana : String, okuri : String?) -> ComposeMode {
+        let candidates = dictionary.find(kana, okuri: okuri)
+        if candidates.isEmpty {
+            return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
+        } else {
+            return .KanjiCompose(kana: kana, okuri: okuri, candidates: candidates, index: 0)
+        }
+    }
+}

--- a/FlickSKKKeyboard/DictionaryEngine.swift
+++ b/FlickSKKKeyboard/DictionaryEngine.swift
@@ -1,0 +1,60 @@
+// SKKの辞書をラップして、フリック入力に適したインターフェースを提供する
+class DictionaryEngine {
+    private let dictionary : SKKDictionary
+    init(dictionary : SKKDictionary){
+        self.dictionary = dictionary
+    }
+
+    // 変換結果を学習する
+    func learn(kana : String, okuri : String?, kanji : String) {
+        // 正規化する
+        let (k, o) = normalize(kana, okuri: okuri)
+
+        // 学習する
+        self.dictionary.learn(k, okuri: o, kanji: kanji)
+    }
+
+    // 辞書を検索する。
+    //  ・ っの特殊ルール等を考慮する
+    func find(kana : String, okuri : String?) -> [String] {
+        // 正規化する
+        let (t, roman) = normalize(kana, okuri: okuri)
+
+        // 辞書を検索する
+        var xs = self.dictionary.find(t, okuri: roman).map({ (x : String)  ->  String in
+            return x + (okuri ?? "")
+        })
+
+        // 末尾が「っ」の場合は、変換位置を1つ前にする
+        if okuri != .None && t.last() == "っ" {
+            // 「っ」送り仮名の場合の特殊処理
+            // https://github.com/codefirst/FlickSKK/issues/27
+            let ys = self.dictionary.find(t.butLast(), okuri: roman).map({ (y : String)  ->  String in
+                return y + "っ" + (okuri ?? "")
+            })
+            xs += ys
+        }
+        return xs
+    }
+
+    // 変換結果を登録する
+    func register(kana : String, okuri : String?, kanji : String) {
+        // 正規化する
+        let (k, o) = normalize(kana, okuri: okuri)
+
+        // 辞書登録
+        dictionary.register(k, okuri: o, kanji: kanji)
+
+    }
+
+    // SKK辞書用に正規化する
+    private func normalize(kana : String, okuri : String?) -> (String, String?) {
+        // 読みをひらかなにする
+        let t = kana.conv(.Hirakana)
+
+        // 送り仮名をローマ字に変換する
+        let roman : String? = okuri?.first()?.toRoman()?.first().map({ c in String(c) })
+
+        return (t, roman)
+    }
+}

--- a/FlickSKKKeyboard/KeyHandler.swift
+++ b/FlickSKKKeyboard/KeyHandler.swift
@@ -2,87 +2,56 @@
 // その際、状態に応じて、テキストの追加・削除を行なう
 class KeyHandler {
     private weak var delegate : SKKDelegate!
-    private let dictionary : SKKDictionary
-
-    private enum Level {
-        // トップレベルのため、iOS側にテキストの追加・削除を伝える
-        case TopLevel
-        // 単語登録モード内のため、仮想的なエリアでテキストの追加・削除をする
-        case Compose(text : String, update : (String) -> Void)
-    }
+    private let dictionary : DictionaryEngine
+    private let text : TextEngine
+    private let factory : ComposeModeFactory
 
     init(delegate : SKKDelegate, dictionary : SKKDictionary) {
         self.delegate = delegate
-        self.dictionary = dictionary
+        self.dictionary = DictionaryEngine(dictionary: dictionary)
+        self.text = TextEngine(delegate: delegate, dictionary: self.dictionary)
+        self.factory = ComposeModeFactory(dictionary: self.dictionary)
     }
 
     func handle(keyEvent : SKKKeyEvent, composeMode : ComposeMode) -> ComposeMode {
-        return dispatch(keyEvent, composeMode: composeMode, level: .TopLevel)
+        return dispatch(keyEvent, composeMode: composeMode, status: .TopLevel)
     }
 
-    private func dispatch(keyEvent: SKKKeyEvent, composeMode: ComposeMode, level: Level) -> ComposeMode {
+    // 現在の状態に応じて、適切なメソッドを呼び分ける
+    private func dispatch(keyEvent: SKKKeyEvent, composeMode: ComposeMode, status: TextEngine.Status) -> ComposeMode {
         switch composeMode {
         case .DirectInput:
-            return directInput(keyEvent, level: level) ?? composeMode
+            return directInput(keyEvent, status: status) ?? composeMode
         case .KanaCompose(kana: let kana, candidates: let candidates):
-            return kanaCompose(keyEvent, kana: kana, candidates: candidates, level: level) ?? composeMode
+            return kanaCompose(keyEvent, kana: kana, candidates: candidates, status: status) ?? composeMode
         case .KanjiCompose(kana: let kana, okuri: let okuri, candidates: let candidates, index : let index):
             return kanjiCompose(keyEvent,
                 kana: kana, okuri: okuri, candidates: candidates, index: index,
-                level: level) ?? composeMode
+                status: status) ?? composeMode
         case .WordRegister(kana: let kana, okuri: let okuri, composeText: let composeText, composeMode: let m):
             return wordRegister(keyEvent,
                 kana: kana, okuri: okuri, composeText: composeText, composeMode: m[0],
-                level: level) ?? composeMode
+                status: status) ?? composeMode
         }
     }
 
-    private func directInput(keyEvent : SKKKeyEvent, level: Level) -> ComposeMode? {
+    // 通常モード
+    private func directInput(keyEvent : SKKKeyEvent, status : TextEngine.Status) -> ComposeMode? {
         switch keyEvent {
         case .Char(kana: let kana, shift : let shift) where !shift:
-            insertText(kana, level: level)
+            text.insert(kana, learn: nil, status: status)
         case .Char(kana: let kana, shift : _): // shiftが押されている
-            return makeKanaCompose(kana)
+            return factory.kanaCompose(kana)
         case .Space:
-            insertText(" ", level: level)
+            text.insert(" ", learn: nil, status: status)
         case .Enter:
-            switch level {
-            case .TopLevel:
-                self.delegate.insertText("\n")
-            case .Compose(text: _, update: let update):
-                update("Please report bug case")
-            }
+            text.insert("\n", learn: nil, status: status)
         case .Backspace:
-            switch level {
-            case .TopLevel:
-                self.delegate.deleteBackward()
-            case .Compose(text: let text, update: let update):
-                update(text.butLast())
-            }
+            text.deleteBackward(status)
         case .ToggleDakuten(beforeText : let beforeText):
-            switch level {
-            case .TopLevel:
-                if let s = beforeText.last()?.toggleDakuten() {
-                    self.delegate.deleteBackward()
-                    self.delegate.insertText(s)
-                }
-            case .Compose(text: let text, update: let update):
-                if let s = text.last()?.toggleDakuten() {
-                    update(text.butLast() + s)
-                }
-            }
+            text.toggleDakuten(beforeText, status: status)
         case .ToggleUpperLower(beforeText: let beforeText):
-            switch level {
-            case .TopLevel:
-                if let s = beforeText.last()?.toggleUpperLower() {
-                    self.delegate.deleteBackward()
-                    self.delegate.insertText(s)
-                }
-            case .Compose(text: let text, update: let update):
-                if let s = text.last()?.toggleUpperLower() {
-                    update(text.butLast() + s)
-                }
-            }
+            text.toggleUpperLower(beforeText, status : status)
         case .InputModeChange(inputMode: let inputMode):
             self.delegate.changeInputMode(inputMode)
         case .Select(_):
@@ -91,54 +60,42 @@ class KeyHandler {
         return nil
     }
 
-    private func makeKanaCompose(kana : String) -> ComposeMode {
-        return .KanaCompose(kana : kana, candidates: consult(kana, okuri: .None))
-    }
-
-    private func makeKanjiCompose(kana : String, okuri : String?) -> ComposeMode {
-        let candidates = consult(kana, okuri: okuri)
-        if candidates.isEmpty {
-            return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
-        } else {
-            return .KanjiCompose(kana: kana, okuri: okuri, candidates: candidates, index: 0)
-        }
-    }
-
-    private func kanaCompose(keyEvent : SKKKeyEvent, kana : String, candidates: [String], level: Level) -> ComposeMode? {
+    // ▽モード
+    private func kanaCompose(keyEvent : SKKKeyEvent, kana : String, candidates: [String], status: TextEngine.Status) -> ComposeMode? {
         switch keyEvent {
         case .Char(kana: let str, shift : let shift) where !shift:
-            return makeKanaCompose(kana + str)
+            return factory.kanaCompose(kana + str)
         case .Char(kana: let str, shift : _): // shiftが押されている
-            return makeKanjiCompose(kana, okuri: str)
+            return factory.kanjiCompose(kana, okuri: str)
         case .Space:
-            return makeKanjiCompose(kana, okuri: .None)
+            return factory.kanjiCompose(kana, okuri: .None)
         case .Enter:
             // かなモードでのEnterは学習しない
-            insertText(kana, level: level)
+            text.insert(kana, learn: nil, status: status)
             return .DirectInput
         case .Backspace where kana.isEmpty:
             return .DirectInput
         case .Backspace:
-            return makeKanaCompose(kana.butLast())
+            return factory.kanaCompose(kana.butLast())
         case .ToggleDakuten(beforeText : _):
             if let s = kana.last()?.toggleDakuten() {
-                return makeKanaCompose(kana.butLast() + s)
+                return factory.kanaCompose(kana.butLast() + s)
             } else {
                 return nil
             }
         case .ToggleUpperLower(beforeText: _):
             if let s = kana.last()?.toggleUpperLower() {
-                return makeKanaCompose(kana.butLast() + s)
+                return factory.kanaCompose(kana.butLast() + s)
             } else {
                 return nil
             }
         case .InputModeChange(inputMode: let inputMode):
-            let str = kana.conv(kanaType(inputMode))
-            insertText(str, level: level)
+            let str = kana.conv(inputMode.kanaType())
+            text.insert(str, learn: nil, status : status)
             return .DirectInput
         case .Select(index: let index):
             if index < candidates.count {
-                decide(kana, okuri : .None, text: candidates[index], level: level)
+                text.insert(candidates[index], learn: (kana, nil), status : status)
                 return .DirectInput
             } else {
                 return .WordRegister(kana : kana, okuri : .None, composeText: "", composeMode : [ .DirectInput ])
@@ -146,15 +103,16 @@ class KeyHandler {
         }
     }
 
+    // ▼モード
     private func kanjiCompose(keyEvent : SKKKeyEvent,
         kana : String, okuri : String?, candidates : [String], index : Int,
-        level : Level) -> ComposeMode? {
+        status : TextEngine.Status) -> ComposeMode? {
         switch keyEvent {
         case .Char(kana: let str, shift : let shift):
-            // 暗黙的に確定する。単語登録中の場合は、levelが更新されるので、次に引き渡す
-            let level = decide(kana, okuri: okuri, text: candidates[index], level: level)
+            // 暗黙的に確定する。単語登録中の場合は、statusが更新されるので、次に引き渡す
+            let status = text.insert(candidates[index], learn: (kana, okuri), status : status)
             // 次の処理を開始する
-            return self.dispatch(keyEvent, composeMode: .DirectInput, level: level)
+            return self.dispatch(keyEvent, composeMode: .DirectInput, status: status)
         case .Space:
             if index + 1 < candidates.count {
                 return .KanjiCompose(kana : kana, okuri : .None, candidates: candidates, index: index + 1)
@@ -162,21 +120,21 @@ class KeyHandler {
                 return .WordRegister(kana : kana, okuri : .None, composeText: "", composeMode : [ .DirectInput ])
             }
         case .Enter:
-            insertText(candidates[index], level: level)
+            text.insert(candidates[index], learn: (kana, okuri), status : status)
             return .DirectInput
         case .Backspace where index == 0:
-            return makeKanaCompose(kana)
+            return factory.kanaCompose(kana)
         case .Backspace:
             return .KanjiCompose(kana : kana, okuri : .None, candidates: candidates, index: index - 1)
         case .ToggleDakuten(beforeText : _):
             if let okuri = okuri?.toggleDakuten() {
-                return makeKanjiCompose(kana, okuri: okuri)
+                return factory.kanjiCompose(kana, okuri: okuri)
             } else {
                 return nil
             }
         case .ToggleUpperLower(beforeText: _):
             if let okuri = okuri?.toggleUpperLower() {
-                return makeKanjiCompose(kana, okuri: okuri)
+                return factory.kanjiCompose(kana, okuri: okuri)
             } else {
                 return nil
             }
@@ -185,7 +143,7 @@ class KeyHandler {
             return nil
         case .Select(index : let index):
             if index < candidates.count {
-                decide(kana, okuri: okuri, text: candidates[index], level: level)
+                text.insert(candidates[index], learn: (kana, okuri), status : status)
                 return .DirectInput
             } else {
                 return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
@@ -193,97 +151,44 @@ class KeyHandler {
         }
     }
 
-    private func decide(kana : String, okuri : String?, text : String, level : Level) -> Level {
-        self.dictionary.learn(kana, okuri: okuri, kanji: text)
-        return insertText(text, level : level)
-    }
-
-    private func insertText(text : String, level : Level) -> Level {
-        switch level {
-        case .TopLevel:
-            self.delegate.insertText(text)
-            return .TopLevel
-        case .Compose(text: let prev, update: let update):
-            update(prev + text)
-            return .Compose(text: prev + text, update: update)
-        }
-    }
-
+    // 単語登録モード
     private func wordRegister(keyEvent : SKKKeyEvent,
         kana : String, okuri: String?, composeText: String, composeMode: ComposeMode,
-        level : Level) -> ComposeMode? {
+        status : TextEngine.Status) -> ComposeMode? {
         switch (composeMode, keyEvent) {
         case (.DirectInput, .Enter):
-            // 送り仮名はローマ字に変換する
-            let okuriRoman = okuri?.first()?.toRoman()?.first().map({c in String(c)})
-
             // 辞書登録
-            dictionary.register(kana, okuri: okuriRoman, kanji: composeText)
+            dictionary.register(kana, okuri: okuri, kanji: composeText)
 
             // composeTextを入力する
-            decide(kana, okuri : okuri, text: composeText + (okuri ?? ""), level: level)
+            text.insert(composeText + (okuri ?? ""), learn: (kana, okuri), status: status)
 
             // 状態遷移
             return .DirectInput
         case (.DirectInput, .Backspace) where composeText.isEmpty:
             // 先頭でバックスペース押した場合は、▽モードに戻る
-            return makeKanaCompose(kana)
+            return factory.kanaCompose(kana)
         case (.DirectInput, .ToggleDakuten(_)) where composeText.isEmpty:
             // 先頭で濁点トグルしたら、再変換する
             if let okuri = okuri?.toggleDakuten() {
-                return makeKanjiCompose(kana, okuri: okuri)
+                return factory.kanjiCompose(kana, okuri: okuri)
             } else {
                 return nil
             }
         case (.DirectInput, .ToggleUpperLower(_)) where composeText.isEmpty:
             // 先頭で大文字・小文字トグルしたら、再変換する
             if let okuri = okuri?.toggleUpperLower() {
-                return makeKanjiCompose(kana, okuri: okuri)
+                return factory.kanjiCompose(kana, okuri: okuri)
             } else {
                 return nil
             }
         default:
+            // それ以外のキーは再帰的に処理する
             var text = composeText
-            let m = dispatch(keyEvent, composeMode: composeMode, level: .Compose(text: text, update: { str in
+            let m = dispatch(keyEvent, composeMode: composeMode, status: .Compose(text: text, update: { str in
                 text = str
             }))
             return .WordRegister(kana: kana, okuri: okuri, composeText: text, composeMode: [m])
         }
     }
-
-    private func kanaType(inputMode : SKKInputMode) -> KanaType {
-        switch inputMode {
-        case .Hirakana:
-            return .Hirakana
-        case .Katakana:
-            return .Katakana
-        case .HankakuKana:
-            return .HankakuKana
-        }
-    }
-
-    private func consult(text : String, okuri : String?) -> [String] {
-        // 正規化する
-        let t = text.conv(.Hirakana)
-
-        // 送り仮名をローマ字に変換する
-        let roman : String? = okuri?.first()?.toRoman()?.first().map({ c in String(c) })
-
-        // 辞書を検索する
-        var xs = self.dictionary.find(t, okuri: roman).map({ (x : String)  ->  String in
-            return x + (okuri ?? "")
-        })
-
-        // 末尾が「っ」の場合は、変換位置を1つ前にする
-        if okuri != .None && t.last() == "っ" {
-            // 「っ」送り仮名の場合の特殊処理
-            // https://github.com/codefirst/FlickSKK/issues/27
-            let ys = self.dictionary.find(t.butLast(), okuri: roman).map({ (y : String)  ->  String in
-                return y + "っ" + (okuri ?? "")
-            })
-            xs += ys
-        }
-        return xs
-    }
-
 }

--- a/FlickSKKKeyboard/KeyboardViewController.swift
+++ b/FlickSKKKeyboard/KeyboardViewController.swift
@@ -336,11 +336,12 @@ class KeyboardViewController: UIInputViewController, SKKDelegate {
 
     private func loadDictionary() {
         let userDict = SKKUserDictionaryFile.defaultUserDictionaryPath()
+        let learnDict = SKKUserDictionaryFile.defaultLearnDictionaryPath()
         let mtime = getModifiedTime(userDict)
 
         if kGlobalDictionary == nil || kLoadedTime != mtime {
             let dict = NSBundle.mainBundle().pathForResource("skk", ofType: "jisyo")
-            kGlobalDictionary = SKKDictionary(userDict: userDict, dicts: [dict!])
+            kGlobalDictionary = SKKDictionary(userDict: userDict, learnDict: learnDict, dicts: [dict!])
             kLoadedTime = mtime
         }
     }

--- a/FlickSKKKeyboard/SKKDictionary.swift
+++ b/FlickSKKKeyboard/SKKDictionary.swift
@@ -13,15 +13,17 @@ class SKKDictionary : NSObject {
 
     var dictionaries : [ SKKDictionaryFile ] = []
     var userDict : SKKUserDictionaryFile?
+    var learnDict : SKKUserDictionaryFile?
 
     dynamic var isWaitingForLoad : Bool = false
     class func isWaitingForLoadKVOKey() -> String { return "isWaitingForLoad" }
 
-    init(userDict: String, dicts : [String]){
+    init(userDict: String, learnDict : String, dicts : [String]){
         super.init()
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
             self.userDict = SKKUserDictionaryFile(path: userDict)
-            self.dictionaries = [ self.userDict! ] + dicts.map({ x -> SKKDictionaryFile in
+            self.learnDict = SKKUserDictionaryFile(path: learnDict)
+            self.dictionaries = [ self.learnDict!, self.userDict! ] + dicts.map({ x -> SKKDictionaryFile in
                 SKKLocalDictionaryFile(path: x)})
             self.initialized = true
         })
@@ -35,7 +37,7 @@ class SKKDictionary : NSObject {
         }).reduce([],
                   combine: {(x : [String], y : [String]) -> [String] in
             x + y
-        })
+        }).unique()
 
         return xs
     }
@@ -44,6 +46,14 @@ class SKKDictionary : NSObject {
         userDict?.register(normal, okuri: okuri, kanji: kanji)
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
             self.userDict?.serialize()
+            ()
+        })
+    }
+
+    func learn(normal : String, okuri: String?, kanji: String) {
+        learnDict?.register(normal, okuri: okuri, kanji: kanji)
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+            self.learnDict?.serialize()
             ()
         })
     }

--- a/FlickSKKKeyboard/SKKInputMode.swift
+++ b/FlickSKKKeyboard/SKKInputMode.swift
@@ -12,4 +12,15 @@ enum SKKInputMode {
     case Hirakana
     case Katakana
     case HankakuKana
+
+    func kanaType() -> KanaType {
+        switch self {
+        case .Hirakana:
+            return .Hirakana
+        case .Katakana:
+            return .Katakana
+        case .HankakuKana:
+            return .HankakuKana
+        }
+    }
 }

--- a/FlickSKKKeyboard/SKKUserDictionaryFile.swift
+++ b/FlickSKKKeyboard/SKKUserDictionaryFile.swift
@@ -19,6 +19,15 @@ class SKKUserDictionaryFile  : SKKDictionaryFile {
         return SKKUserDictionaryFile(path: self.defaultUserDictionaryPath())
     }
 
+    class func defaultLearnDictionaryPath() -> String {
+        return AppGroup.pathForResource("Library/skk.learn.jisyo") ??
+            NSHomeDirectory().stringByAppendingPathComponent("Library/skk.learn.jisyo")
+    }
+    class func defaultLearnDictionary() -> SKKUserDictionaryFile {
+        return SKKUserDictionaryFile(path: self.defaultUserDictionaryPath())
+    }
+
+
     // REMARK: Swift dictionary is too slow. So, we need use NSMutableDictionary.
     // [String:String]相当の実装になってる
     var okuriAri  = NSMutableDictionary()

--- a/FlickSKKKeyboard/TextEngine.swift
+++ b/FlickSKKKeyboard/TextEngine.swift
@@ -1,0 +1,80 @@
+// トップレベルと、単語登録モードではテキストの挿入先が異なる。
+// そこを抽象化する。
+
+class TextEngine {
+    enum Status {
+        // トップレベルのため、iOS側にテキストの追加・削除を伝える
+        case TopLevel
+        // 単語登録モード内のため、仮想的なエリアでテキストの追加・削除をする
+        case Compose(text : String, update : (String) -> Void)
+    }
+
+    private let dictionary : DictionaryEngine
+    private let delegate : SKKDelegate
+
+    init(delegate : SKKDelegate, dictionary : DictionaryEngine) {
+        self.delegate = delegate
+        self.dictionary = dictionary
+    }
+
+    // テキストを確定させる。 learnを指定していれば、変換結果の学習も行なう。
+    func insert(text : String, learn : (String, String?)?, status : Status) -> Status {
+        if let (kana, okuri) = learn {
+            self.dictionary.learn(kana, okuri: okuri, kanji: text)
+        }
+        return insertText(text, status : status)
+    }
+
+    // 最後の一文字を消す
+    func deleteBackward(status : Status) {
+        switch status {
+        case .TopLevel:
+            self.delegate.deleteBackward()
+        case .Compose(text: let text, update: let update):
+            let s = text.butLast()
+            update(s)
+        }
+    }
+
+    // 最後と一文字を濁点にする
+    func toggleDakuten(beforeText : String, status : Status) {
+        switch status {
+        case .TopLevel:
+            if let s = beforeText.last()?.toggleDakuten() {
+                self.delegate.deleteBackward()
+                self.delegate.insertText(s)
+            }
+        case .Compose(text: let text, update: let update):
+            if let s = text.last()?.toggleDakuten() {
+                update(text.butLast() + s)
+            }
+        }
+    }
+
+    // 最後と一文字を大文字にする
+    func toggleUpperLower(beforeText : String, status : Status) {
+        switch status {
+        case .TopLevel:
+            if let s = beforeText.last()?.toggleUpperLower() {
+                self.delegate.deleteBackward()
+                self.delegate.insertText(s)
+            }
+        case .Compose(text: let text, update: let update):
+            if let s = text.last()?.toggleUpperLower() {
+                update(text.butLast() + s)
+            }
+        }
+    }
+
+    private func insertText(text : String, status : Status) -> Status {
+        switch status {
+        case .TopLevel:
+            self.delegate.insertText(text)
+            return .TopLevel
+        case .Compose(text: let prev, update: let update):
+            update(prev + text)
+            return .Compose(text: prev + text, update: update)
+        }
+    }
+}
+

--- a/FlickSKKKeyboard/Utilities.swift
+++ b/FlickSKKKeyboard/Utilities.swift
@@ -462,3 +462,17 @@ extension String {
         }
     }
 }
+
+extension Array {
+    func unique <T: Hashable> () -> [T] {
+        var result = [T]()
+        var addedDict = [T: Bool]()
+        for elem in self {
+            if addedDict[elem as T] == nil {
+                addedDict[elem as T] = true
+                result.append(elem as T)
+            }
+        }
+        return result
+    }
+}

--- a/FlickSKKTests/KeyHandlerSpec.swift
+++ b/FlickSKKTests/KeyHandlerSpec.swift
@@ -19,11 +19,13 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
     override func spec() {
         var handler : KeyHandler!
         let bundle = NSBundle(forClass: self.classForCoder)
+        let learn = SKKUserDictionaryFile.defaultLearnDictionaryPath()
         let jisyo = bundle.pathForResource("skk", ofType: "jisyo")
-        let dict = SKKDictionary(userDict: "", dicts:[jisyo!])
+        let dict = SKKDictionary(userDict: "", learnDict : learn, dicts:[jisyo!])
         dict.waitForLoading()
 
         beforeEach {
+            NSFileManager.defaultManager().removeItemAtPath(learn, error: nil)
             handler = KeyHandler(delegate: self, dictionary: dict)
             self.insertedText = ""
             self.inputMode = .Hirakana
@@ -190,6 +192,8 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
                     let m = handler.handle(.Select(index: 0), composeMode: composeMode)
                     expect(self.insertedText).to(equal("川"))
                     expect(m == .DirectInput).to(beTrue())
+                    // 学習したものが先頭にくる
+                    expect(dict.find("かわ", okuri: nil)[0]).to(equal("川"))
                 }
                 it("単語登録モード") {
                     let m = handler.handle(.Select(index: 2), composeMode: composeMode)
@@ -213,6 +217,8 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
                 let m = handler.handle(.Char(kana: "に", shift: false), composeMode: composeMode)
                 expect(self.insertedText).to(equal("川に"))
                 expect(m == .DirectInput).to(beTrue())
+                // 学習したものが先頭にくる
+                expect(dict.find("かわ", okuri: nil)[0]).to(equal("川"))
             }
             describe("Space") {
                 it("単語がある場合") {
@@ -237,6 +243,8 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
                 let m = handler.handle(.Enter, composeMode: composeMode)
                 expect(m == .DirectInput).to(beTrue())
                 expect(self.insertedText).to(equal("川"))
+                // 学習したものが先頭にくる
+                expect(dict.find("かわ", okuri: nil)[0]).to(equal("川"))
             }
             describe("Backspace") {
                 it("index == 0") {
@@ -277,6 +285,8 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
                     let m = handler.handle(.Select(index: 0), composeMode: composeMode)
                     expect(self.insertedText).to(equal("川"))
                     expect(m == .DirectInput).to(beTrue())
+                    // 学習したものが先頭にくる
+                    expect(dict.find("かわ", okuri: nil)[0]).to(equal("川"))
                 }
                 it("単語登録モード") {
                     let m = handler.handle(.Select(index: 2), composeMode: composeMode)
@@ -326,7 +336,7 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
                         .WordRegister(kana: "まじ", okuri: .None, composeText : "本気", composeMode: [ .DirectInput ]))
                     expect(m == .DirectInput).to(beTrue())
                     expect(self.insertedText).to(equal("本気"))
-                    expect(dict.find("まじ", okuri: .None)).to(contain("本気"))
+                    expect(dict.find("まじ", okuri: .None)[0]).to(equal("本気"))
                 }
                 it("送りあり") {
                     let m = handler.handle(.Enter, composeMode:
@@ -451,6 +461,8 @@ class KeyHandlerSpec : QuickSpec, SKKDelegate {
                     expect(k).to(equal("まじ"))
                     expect(okuri).to(beNil())
                     expect(composeText).to(equal("か山"))
+                    // 学習したものが先頭にくる
+                    expect(dict.find("やま", okuri: nil)[0]).to(equal("山"))
                 default:
                     fail()
                 }


### PR DESCRIPTION
学習用の辞書に、最後の変換結果を保存するようにした。

## 他のSKKとの違い
他のSKKでは学習用の辞書とユーザ辞書は同一にする。 ただ、

 - ユーザ辞書は別のマシンと共有したり、バックアップしたい
 - 学習用辞書はリセットしたりしたい

といった性質の違いがあるので、別ファイルにした。

## スクリーンショット
### 変換1回目
![screen shot 2015-02-25 at 11 58 47 pm](https://cloud.githubusercontent.com/assets/9650/6373047/9e3d55da-bd4b-11e4-81aa-5c3d486f8d8c.png)

### 変換2回目
![screen shot 2015-02-25 at 11 58 54 pm](https://cloud.githubusercontent.com/assets/9650/6373048/a46feada-bd4b-11e4-8be9-577dfb37f8d3.png)
