### PR TITLE
KeyButtonに各フリック方向の文字を表示(記号のみ)

### DIFF
--- a/FlickSKKKeyboard/KeyButton.swift
+++ b/FlickSKKKeyboard/KeyButton.swift
@@ -38,6 +38,20 @@ class KeyButton: UIView, UIGestureRecognizerDelegate {
             autolayout("V:|-p-[iv]-p-|")
         }
     }()
+    lazy var sequenceLabel: UILabel = { [unowned self] in
+        UILabel().tap { (l: UILabel) in
+            if let seq = self.key.sequence {
+                let left = seq.count > 1 ? seq[1] : " "
+                let top = seq.count > 2 ? seq[2] : " "
+                let right = seq.count > 3 ? seq[3] : " "
+                let bottom = seq.count > 4 ? seq[4] : " "
+                l.text = left + bottom + top + right
+            }
+            l.font = Appearance.normalFont(12)
+            l.textColor = UIColor.lightGrayColor()
+            l.textAlignment = .Center
+        }
+    }()
 
     var metrics: [String:CGFloat] {
         return ["p": 10]
@@ -92,13 +106,20 @@ class KeyButton: UIView, UIGestureRecognizerDelegate {
                 return ()
             })
         }
-
-        let views = [
-            "label": label,
-        ]
-        let autolayout = self.autolayoutFormat(metrics, views)
-        autolayout("H:|[label]|")
-        autolayout("V:|[label]|")
+        switch key {
+        case .Seq(_):
+            let autolayout = self.autolayoutFormat(metrics, ["label": label, "sequence": sequenceLabel])
+            autolayout("H:|[label]|")
+            autolayout("H:|[sequence]|")
+//            addConstraint(NSLayoutConstraint(
+//                item: label, attribute: .CenterY, relatedBy: .Equal,
+//                toItem: self, attribute: .CenterY, multiplier: 1, constant: 0))
+            autolayout("V:[label]-2-[sequence]-2-|")
+        default:
+            let autolayout = self.autolayoutFormat(metrics, ["label": label])
+            autolayout("H:|[label]|")
+            autolayout("V:|[label]|")
+        }
 
         self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: "gestureTapped:"))
         self.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: "gesturePanned:"))

--- a/FlickSKKKeyboard/KeyButton.swift
+++ b/FlickSKKKeyboard/KeyButton.swift
@@ -40,13 +40,7 @@ class KeyButton: UIView, UIGestureRecognizerDelegate {
     }()
     lazy var sequenceLabel: UILabel = { [unowned self] in
         UILabel().tap { (l: UILabel) in
-            if let seq = self.key.sequence {
-                let left = seq.count > 1 ? seq[1] : " "
-                let top = seq.count > 2 ? seq[2] : " "
-                let right = seq.count > 3 ? seq[3] : " "
-                let bottom = seq.count > 4 ? seq[4] : " "
-                l.text = left + bottom + top + right
-            }
+            l.text = self.key.additionalButtonLabel
             l.font = Appearance.normalFont(12)
             l.textColor = UIColor.lightGrayColor()
             l.textAlignment = .Center
@@ -107,13 +101,10 @@ class KeyButton: UIView, UIGestureRecognizerDelegate {
             })
         }
         switch key {
-        case .Seq(_):
+        case .Seq(_, showSeqs: true):
             let autolayout = self.autolayoutFormat(metrics, ["label": label, "sequence": sequenceLabel])
             autolayout("H:|[label]|")
             autolayout("H:|[sequence]|")
-//            addConstraint(NSLayoutConstraint(
-//                item: label, attribute: .CenterY, relatedBy: .Equal,
-//                toItem: self, attribute: .CenterY, multiplier: 1, constant: 0))
             autolayout("V:[label]-2-[sequence]-2-|")
         default:
             let autolayout = self.autolayoutFormat(metrics, ["label": label])


### PR DESCRIPTION
#62 対応

確認用に「1」に「←↓↑→」追加してます。

![screen shot 2015-02-28 at 21 47 34](https://cloud.githubusercontent.com/assets/11156/6426218/7cc703fc-bf93-11e4-8bdf-8dd0073f8d9d.png)
![screen shot 2015-02-28 at 21 47 37](https://cloud.githubusercontent.com/assets/11156/6426219/7e25fd16-bf93-11e4-925f-ef345e3d13de.png)
![screen shot 2015-02-28 at 21 47 40](https://cloud.githubusercontent.com/assets/11156/6426220/7f5072d4-bf93-11e4-9bea-077b3f7dd8ea.png)


