### PR TITLE
送り仮名付きの変換結果学習が、送り仮名ごと学習してしまう不具合を修正

### DIFF
--- a/FlickSKKKeyboard/KeyHandler.swift
+++ b/FlickSKKKeyboard/KeyHandler.swift
@@ -115,9 +115,9 @@ class KeyHandler {
             return self.dispatch(keyEvent, composeMode: .DirectInput, status: status)
         case .Space:
             if index + 1 < candidates.count {
-                return .KanjiCompose(kana : kana, okuri : .None, candidates: candidates, index: index + 1)
+                return .KanjiCompose(kana : kana, okuri : okuri, candidates: candidates, index: index + 1)
             } else {
-                return .WordRegister(kana : kana, okuri : .None, composeText: "", composeMode : [ .DirectInput ])
+                return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
             }
         case .Enter:
             text.insert(candidates[index], learn: (kana, okuri), status : status)

--- a/FlickSKKKeyboard/TextEngine.swift
+++ b/FlickSKKKeyboard/TextEngine.swift
@@ -20,7 +20,13 @@ class TextEngine {
     // テキストを確定させる。 learnを指定していれば、変換結果の学習も行なう。
     func insert(text : String, learn : (String, String?)?, status : Status) -> Status {
         if let (kana, okuri) = learn {
-            self.dictionary.learn(kana, okuri: okuri, kanji: text)
+            if okuri == nil {
+                self.dictionary.learn(kana, okuri: okuri, kanji: text)
+            } else {
+                // 送り仮名がある場合、textは送り仮名付きになっている。
+                // 辞書には送り仮名以外の部分を登録する必要がある。
+                self.dictionary.learn(kana, okuri: okuri, kanji: text.butLast())
+            }
         }
         return insertText(text, status : status)
     }

--- a/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
@@ -88,9 +88,7 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                     let m = handler.handle(.Select(index: 0), composeMode: composeMode)
                     expect(delegate.insertedText).to(equal("川"))
                     expect(m == .DirectInput).to(beTrue())
-                    // 学習したものが先頭にくる
-                    expect(self.dictionary.find("かわ", okuri: nil)[0]).to(equal("川"))
-                }
+                                   }
                 it("単語登録モード") {
                     let m = handler.handle(.Select(index: 2), composeMode: composeMode)
                     switch m {
@@ -102,6 +100,24 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                     default:
                         fail()
                     }
+                }
+            }
+            describe("学習") {
+                it("送りなし") {
+                    let m = handler.handle(.Select(index: 0), composeMode: composeMode)
+                    // 学習したものが先頭にくる
+                    expect(self.dictionary.find("かわ", okuri: nil)[0]).to(equal("川"))
+                }
+                it("送りあり") {
+                    let composeMode = ComposeMode.KanjiCompose(kana: "い", okuri: "る", candidates: ["入る", "居る"], index: 0)
+                    let m = handler.handle(.Select(index: 1), composeMode: composeMode)
+
+                    // 学習したものが先頭にくる
+                    let xs = self.dictionary.find("い", okuri: "r")
+                    expect(xs).notTo(beEmpty())
+
+                    // 送り仮名は学習しない
+                    expect(xs[0]).to(equal("居"))
                 }
             }
         }

--- a/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
@@ -27,6 +27,15 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                 it("単語がある場合") {
                     let m = handler.handle(.Space, composeMode: composeMode)
                     let (kana, okuri) = self.kanji(m)!
+                    expect(kana).to(equal("かわ"))
+                    expect(okuri).to(equal(""))
+                    expect(self.index(m)).to(equal(1))
+                }
+                it("送り仮名がある場合") {
+                    let m = handler.handle(.Space, composeMode: ComposeMode.KanjiCompose(kana: "い", okuri: "る", candidates: ["居る", "入る"], index: 0))
+                    let (kana, okuri) = self.kanji(m)!
+                    expect(kana).to(equal("い"))
+                    expect(okuri).to(equal("る"))
                     expect(self.index(m)).to(equal(1))
                 }
                 it("単語がない場合") {


### PR DESCRIPTION
こんな感じの不具合を修正します。

![screen shot 2015-03-02 at 12 57 43 am](https://cloud.githubusercontent.com/assets/9650/6431590/81dd945c-c077-11e4-8219-928772e8a12f.png)
