### PR TITLE
SKKDelegateに対する循環参照が発生し、メモリリークしていたので修正

### DIFF
--- a/FlickSKKKeyboard/TextEngine.swift
+++ b/FlickSKKKeyboard/TextEngine.swift
@@ -10,7 +10,7 @@ class TextEngine {
     }
 
     private let dictionary : DictionaryEngine
-    private let delegate : SKKDelegate
+    private weak var delegate : SKKDelegate?
 
     init(delegate : SKKDelegate, dictionary : DictionaryEngine) {
         self.delegate = delegate
@@ -29,7 +29,7 @@ class TextEngine {
     func deleteBackward(status : Status) {
         switch status {
         case .TopLevel:
-            self.delegate.deleteBackward()
+            self.delegate?.deleteBackward()
         case .Compose(text: let text, update: let update):
             let s = text.butLast()
             update(s)
@@ -41,8 +41,8 @@ class TextEngine {
         switch status {
         case .TopLevel:
             if let s = beforeText.last()?.toggleDakuten() {
-                self.delegate.deleteBackward()
-                self.delegate.insertText(s)
+                self.delegate?.deleteBackward()
+                self.delegate?.insertText(s)
             }
         case .Compose(text: let text, update: let update):
             if let s = text.last()?.toggleDakuten() {
@@ -56,8 +56,8 @@ class TextEngine {
         switch status {
         case .TopLevel:
             if let s = beforeText.last()?.toggleUpperLower() {
-                self.delegate.deleteBackward()
-                self.delegate.insertText(s)
+                self.delegate?.deleteBackward()
+                self.delegate?.insertText(s)
             }
         case .Compose(text: let text, update: let update):
             if let s = text.last()?.toggleUpperLower() {
@@ -69,7 +69,7 @@ class TextEngine {
     private func insertText(text : String, status : Status) -> Status {
         switch status {
         case .TopLevel:
-            self.delegate.insertText(text)
+            self.delegate?.insertText(text)
             return .TopLevel
         case .Compose(text: let prev, update: let update):
             update(prev + text)


### PR DESCRIPTION
FlickSKKのクラッシュ頻度があがったので、その修正したくて、実機でデバッグ実行した。
その結果、メモリが2MBほどリークしてるっぽい。

KeyboardViewControllerのdeinitがよばれていなかったため、KeyboardViewController もしくは SKKDelegate を weakなしで参照しているTextEngineを、それをweak参照に変更した。

導入されたのが https://github.com/codefirst/FlickSKK/pull/30 なので、1.2.0には影響ないはず。
