### PR TITLE
▽モードで文字が空になったら、▽モードを抜けるようにした

### DIFF
--- a/FlickSKKKeyboard/KeyHandler.swift
+++ b/FlickSKKKeyboard/KeyHandler.swift
@@ -73,10 +73,14 @@ class KeyHandler {
             // かなモードでのEnterは学習しない
             text.insert(kana, learn: nil, status: status)
             return .DirectInput
-        case .Backspace where kana.isEmpty:
-            return .DirectInput
         case .Backspace:
-            return factory.kanaCompose(kana.butLast())
+            let str = kana.butLast()
+
+            if str.isEmpty {
+                return .DirectInput
+            } else {
+                return factory.kanaCompose(str)
+            }
         case .ToggleDakuten(beforeText : _):
             if let s = kana.last()?.toggleDakuten() {
                 return factory.kanaCompose(kana.butLast() + s)

--- a/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
@@ -50,8 +50,8 @@ class KeyHandlerKanaComposeSpec : KeyHandlerBaseSpec {
                     let m = handler.handle(.Backspace, composeMode: composeMode)
                     expect(self.kana(m)).to(equal("か"))
                 }
-                it("文字がない場合") {
-                    let m = handler.handle(.Backspace, composeMode: .KanaCompose(kana: "", candidates: []))
+                it("文字がなくなる場合") {
+                    let m = handler.handle(.Backspace, composeMode: .KanaCompose(kana: "か", candidates: []))
                     expect(m == .DirectInput).to(beTrue())
                 }
             }


### PR DESCRIPTION
#103 の別解です。

どっちかをマージしましょう。