### PR TITLE
/などの辞書のエントリに使えない文字をエスケープするようにした

### DIFF
--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		134721791AB8E4EB0047BB27 /* KeyboardMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134721781AB8E4EB0047BB27 /* KeyboardMode.swift */; };
 		1347217D1AB8E7E70047BB27 /* KeyboardMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134721781AB8E4EB0047BB27 /* KeyboardMode.swift */; };
 		1347217E1AB8E7EC0047BB27 /* KanaFlickKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134721761AB8E4DD0047BB27 /* KanaFlickKey.swift */; };
+		134721801AB8ED170047BB27 /* EntryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1347217F1AB8ED170047BB27 /* EntryParser.swift */; };
+		134721811AB8ED170047BB27 /* EntryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1347217F1AB8ED170047BB27 /* EntryParser.swift */; };
+		134721821AB8EF2B0047BB27 /* EntryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1347217F1AB8ED170047BB27 /* EntryParser.swift */; };
 		134DE87B1AAC0CAD00FF9CE5 /* DictionaryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FAB2101AAB3AF30014C218 /* DictionaryCache.swift */; };
 		135A44BB1A881F070089F84E /* ComposeModePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135A44B91A881F070089F84E /* ComposeModePresenter.swift */; };
 		135A44BD1A88203E0089F84E /* ComposeModePresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135A44BC1A88203E0089F84E /* ComposeModePresenterSpec.swift */; };
@@ -192,6 +195,7 @@
 		1341A24819E96A7F00EE8AFA /* SKKDictionaryLocalFileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionaryLocalFileSpec.swift; sourceTree = "<group>"; };
 		134721761AB8E4DD0047BB27 /* KanaFlickKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KanaFlickKey.swift; sourceTree = "<group>"; };
 		134721781AB8E4EB0047BB27 /* KeyboardMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardMode.swift; sourceTree = "<group>"; };
+		1347217F1AB8ED170047BB27 /* EntryParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntryParser.swift; sourceTree = "<group>"; };
 		135A44B91A881F070089F84E /* ComposeModePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeModePresenter.swift; sourceTree = "<group>"; };
 		135A44BC1A88203E0089F84E /* ComposeModePresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeModePresenterSpec.swift; sourceTree = "<group>"; };
 		136610B61AA00FFB006AA8F1 /* KeyHandlerDirectInputSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyHandlerDirectInputSpec.swift; sourceTree = "<group>"; };
@@ -329,6 +333,7 @@
 				13FAB2101AAB3AF30014C218 /* DictionaryCache.swift */,
 				131D013E1AABF1830085E83C /* AsyncLoader.swift */,
 				131D01421AABF60C0085E83C /* DictionarySettings.swift */,
+				1347217F1AB8ED170047BB27 /* EntryParser.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -881,6 +886,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAD4B56819D5CB50007B6636 /* MainMenuViewController.swift in Sources */,
+				134721821AB8EF2B0047BB27 /* EntryParser.swift in Sources */,
 				EAF1DB6F19FBFDFD00816CF5 /* AppGroup.m in Sources */,
 				131D01411AABF3090085E83C /* AsyncLoader.swift in Sources */,
 				131D01431AABF60C0085E83C /* DictionarySettings.swift in Sources */,
@@ -910,6 +916,7 @@
 				1347217D1AB8E7E70047BB27 /* KeyboardMode.swift in Sources */,
 				1347217E1AB8E7EC0047BB27 /* KanaFlickKey.swift in Sources */,
 				13F9326D19E2DC1700AC5019 /* KeyPad.swift in Sources */,
+				134721801AB8ED170047BB27 /* EntryParser.swift in Sources */,
 				131D013F1AABF1830085E83C /* AsyncLoader.swift in Sources */,
 				136610C31AA032C1006AA8F1 /* KeyHandlerKanjiComposeSpec.swift in Sources */,
 				13F9326119E2DC1700AC5019 /* SKKDelegate.swift in Sources */,
@@ -977,6 +984,7 @@
 				13FAB2121AAB3AF30014C218 /* DictionaryCache.swift in Sources */,
 				13E33E7F1A9E855500CD1140 /* DictionaryEngine.swift in Sources */,
 				EA2D4D7F19E173EC00607C35 /* KeyButtonFlickPopup.swift in Sources */,
+				134721811AB8ED170047BB27 /* EntryParser.swift in Sources */,
 				1306495D1A8721180044B225 /* SKKKeyEvent.swift in Sources */,
 				13F4525419DC5399001A4A1B /* IOUtil.mm in Sources */,
 				133432C11A4D95030080280F /* SKKNumberPreprocessor.swift in Sources */,

--- a/FlickSKKKeyboard/EntryParser.swift
+++ b/FlickSKKKeyboard/EntryParser.swift
@@ -1,0 +1,64 @@
+class EntryParser {
+    private let entry : String
+
+    init(entry : String) {
+        self.entry = entry
+    }
+
+    // 登録されている単語一覧を取得
+    func words() -> [String] {
+        let xs = self.entry.pathComponents
+        if xs.count <= 2 {
+            return []
+        } else {
+            return Array(xs[1...xs.count-2]).map { x in self.unescape(x) }
+        }
+    }
+
+    // 単語を追加
+    func append(word : String) -> String {
+        let xs = words()
+        if contains(xs, word) {
+            return self.entry
+        } else {
+            return join([ word ] + xs)
+        }
+    }
+
+    // 単語の削除
+    func remove(word : String) -> String? {
+        let xs = words().filter({ x in
+            x != word
+        })
+
+        if xs.isEmpty {
+            return nil
+        } else {
+            return join(xs)
+        }
+    }
+
+    // 単語リストを結合して、SKKのエントリにする
+    //  ["a", "b"] => /a/b/
+    private func join(xs : [String]) -> String {
+        return xs.reduce("", {(x,y) in x + "/" + self.escape(y) }) + "/"
+    }
+
+    // 特殊な文字は置換する。
+    // 置換方式はSKKによって違うが、ここではAquaSKKと同様に[xx]に置換する方式を取る。
+    private let EscapeStrings = [("[","[5b]"), ("/", "[2f]"), (";","[3b]")]
+
+    private func escape(str : String) -> String {
+        return EscapeStrings.reduce(str) { (str, x) in
+            let (from, to) = x
+            return str.stringByReplacingOccurrencesOfString(from, withString: to, options: nil, range: nil)
+        }
+    }
+
+    private func unescape(str : String) -> String {
+        return EscapeStrings.reduce(str) { (str, x) in
+            let (from, to) = x
+            return str.stringByReplacingOccurrencesOfString(to, withString: from, options: nil, range: nil)
+        }
+    }
+}

--- a/FlickSKKTests/SKKDictionaryUserFileSpec.swift
+++ b/FlickSKKTests/SKKDictionaryUserFileSpec.swift
@@ -20,18 +20,46 @@ class SKKDictionaryUserFileSpec : QuickSpec {
                 dict = SKKUserDictionaryFile(path: path)
             }
 
-            it("can find register entry") {
-                dict.register("まじ", okuri: .None, kanji: "本気")
-                let xs = dict.find("まじ", okuri: .None)
-                expect(xs).to(contain("本気"))
-            }
-            it("can serialize entries") {
-                dict.register("まじ", okuri: .None, kanji: "本気")
-                dict.serialize()
+            describe("register") {
+                it("can find register entry") {
+                    dict.register("まじ", okuri: .None, kanji: "本気")
+                    let xs = dict.find("まじ", okuri: .None)
+                    expect(xs).to(contain("本気"))
+                }
 
-                let dict2 = SKKUserDictionaryFile(path: path)
-                let xs = dict2.find("まじ", okuri: .None)
-                expect(xs).to(contain("本気"))
+                it("空文字が登録されない") {
+                    dict.register("まじ", okuri: .None, kanji: "本気")
+                    dict.register("まじ", okuri: .None, kanji: "AAA")
+                    let xs = dict.find("まじ", okuri: .None)
+                    expect(xs).toNot(contain(""))
+                }
+
+                it("特殊な文字も登録できる") {
+                    dict.register("まじ", okuri: .None, kanji: "foo/bar;baz[xyzzy]")
+                    let xs = dict.find("まじ", okuri: .None)
+                    expect(xs).to(contain("foo/bar;baz[xyzzy]"))
+                }
+            }
+
+            describe("serialize") {
+                it("can serialize entries") {
+                    dict.register("まじ", okuri: .None, kanji: "本気")
+                    dict.serialize()
+
+                    let dict2 = SKKUserDictionaryFile(path: path)
+                    let xs = dict2.find("まじ", okuri: .None)
+                    expect(xs).to(contain("本気"))
+                }
+
+                it("特殊な文字も登録できる") {
+                    dict.register("まじ", okuri: .None, kanji: "foo/bar;baz[xyzzy]")
+                    dict.serialize()
+
+
+                    let dict2 = SKKUserDictionaryFile(path: path)
+                    let xs = dict2.find("まじ", okuri: .None)
+                    expect(xs).to(contain("foo/bar;baz[xyzzy]"))
+                }
             }
             it("return sorted entries") {
                 dict.register("あああ", okuri: .None, kanji: "AAA")


### PR DESCRIPTION
https://github.com/codefirst/FlickSKK/issues/91 の対応です。

![screen shot 2015-03-18 at 11 02 41 am](https://cloud.githubusercontent.com/assets/9650/6701389/5b5dcf1e-cd5f-11e4-89cc-3d3ebc50de03.png)

なおエスケープにはいくつかのスタイルがある。

 *  L辞書: elispでエスケープする。 例: ao /(concat "and\057or")/
 * AquaSKK: [xx]でエスケープする。例: foo /foo[2f]/

よりシンプルなAquaSKKスタイルを採用した。