### PR TITLE
同じ読みの単語を複数個学習しても、最後の学習結果が先頭に来ない不具合の修正

### DIFF
--- a/FlickSKKKeyboard/EntryParser.swift
+++ b/FlickSKKKeyboard/EntryParser.swift
@@ -17,12 +17,10 @@ class EntryParser {
 
     // 単語を追加
     func append(word : String) -> String {
-        let xs = words()
-        if contains(xs, word) {
-            return self.entry
-        } else {
-            return join([ word ] + xs)
-        }
+        let xs = words().filter({ x in
+            x != word
+        })
+        return join([ word ] + xs)
     }
 
     // 単語の削除

--- a/FlickSKKTests/SKKDictionaryUserFileSpec.swift
+++ b/FlickSKKTests/SKKDictionaryUserFileSpec.swift
@@ -39,6 +39,14 @@ class SKKDictionaryUserFileSpec : QuickSpec {
                     let xs = dict.find("まじ", okuri: .None)
                     expect(xs).to(contain("foo/bar;baz[xyzzy]"))
                 }
+
+                it("同じ単語を複数回登録すると先頭に来る") {
+                    dict.register("まじ", okuri: .None, kanji: "本気")
+                    dict.register("まじ", okuri: .None, kanji: "AAA")
+                    dict.register("まじ", okuri: .None, kanji: "本気")
+                    let xs = dict.find("まじ", okuri: .None)
+                    expect(xs[0]).to(equal("本気"))
+                }
             }
 
             describe("serialize") {


### PR DESCRIPTION
## 再現方法

 1. 「じまえ」を「自前」で変換する
 2. 「じまえ」を「時前」で変換する
 3. 「じまえ」を「自前」で変換する

## 発生する状況
変換候補が「時前」「自前」の順番になる。

## なってほしい状況
変換候補が「自前」「時前」の順番になる。

## 原因
登録済の単語を再登録しようとした場合、並び順が変化しないため。