### PR TITLE
タブでダイナミック補完する

### DIFF
--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1306495D1A8721180044B225 /* SKKKeyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1306495C1A8721180044B225 /* SKKKeyEvent.swift */; };
 		1306495E1A8723150044B225 /* KeyHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1306495A1A871FEE0044B225 /* KeyHandler.swift */; };
 		1306495F1A8723170044B225 /* SKKKeyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1306495C1A8721180044B225 /* SKKKeyEvent.swift */; };
+		1307DDED1ABD6DCF00678358 /* TextEngineSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1307DDEC1ABD6DCF00678358 /* TextEngineSpec.swift */; };
 		130CA3901A4EF94C00A84D24 /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */; };
 		130CA3961A4EF99800A84D24 /* NumberFormatterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CA3951A4EF99800A84D24 /* NumberFormatterSpec.swift */; };
 		130CA3971A4EFA3F00A84D24 /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */; };
@@ -189,6 +190,7 @@
 		0CA289C0ED7662F2EF0F3718 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		1306495A1A871FEE0044B225 /* KeyHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyHandler.swift; sourceTree = "<group>"; };
 		1306495C1A8721180044B225 /* SKKKeyEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKKeyEvent.swift; sourceTree = "<group>"; };
+		1307DDEC1ABD6DCF00678358 /* TextEngineSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextEngineSpec.swift; sourceTree = "<group>"; };
 		130CA38F1A4EF94C00A84D24 /* NumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormatter.swift; sourceTree = "<group>"; };
 		130CA3951A4EF99800A84D24 /* NumberFormatterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormatterSpec.swift; sourceTree = "<group>"; };
 		131D013E1AABF1830085E83C /* AsyncLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncLoader.swift; sourceTree = "<group>"; };
@@ -452,6 +454,7 @@
 				136610C81AA034BF006AA8F1 /* KeyHandler */,
 				135A44BC1A88203E0089F84E /* ComposeModePresenterSpec.swift */,
 				137B0FC11ABD257600AF08F0 /* DictionaryEngineSpec.swift */,
+				1307DDEC1ABD6DCF00678358 /* TextEngineSpec.swift */,
 			);
 			name = SKKEngine;
 			sourceTree = "<group>";
@@ -960,6 +963,7 @@
 				13DFEAC419F07A1F006D7E40 /* SKKDictionaryFile.swift in Sources */,
 				138EB8601A9035D300CB16BC /* Appearance.swift in Sources */,
 				137AAB4E1A3C13970092F8A5 /* KeyRepeatTimer.swift in Sources */,
+				1307DDED1ABD6DCF00678358 /* TextEngineSpec.swift in Sources */,
 				13FAB2111AAB3AF30014C218 /* DictionaryCache.swift in Sources */,
 				1341A24919E96A7F00EE8AFA /* SKKDictionaryLocalFileSpec.swift in Sources */,
 				13F9326619E2DC1700AC5019 /* IOUtil.mm in Sources */,

--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		136F409919E9D5ED009E3983 /* SKKDictionaryUserFileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136F409819E9D5ED009E3983 /* SKKDictionaryUserFileSpec.swift */; };
 		137AAB451A3C0F3F0092F8A5 /* KeyRepeatTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137AAB441A3C0F3F0092F8A5 /* KeyRepeatTimer.swift */; };
 		137AAB4E1A3C13970092F8A5 /* KeyRepeatTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137AAB441A3C0F3F0092F8A5 /* KeyRepeatTimer.swift */; };
+		137B0FC21ABD257600AF08F0 /* DictionaryEngineSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137B0FC11ABD257600AF08F0 /* DictionaryEngineSpec.swift */; };
 		1388669A1A09202500B7D8A4 /* SKKDictionaryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138866981A09202500B7D8A4 /* SKKDictionaryEntry.swift */; };
 		1388669B1A09204300B7D8A4 /* SKKDictionaryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138866981A09202500B7D8A4 /* SKKDictionaryEntry.swift */; };
 		1388669C1A0920D500B7D8A4 /* SKKDictionaryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138866981A09202500B7D8A4 /* SKKDictionaryEntry.swift */; };
@@ -211,6 +212,7 @@
 		136D161019DAA0AE0091D6BF /* SKKInputMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKInputMode.swift; sourceTree = "<group>"; };
 		136F409819E9D5ED009E3983 /* SKKDictionaryUserFileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionaryUserFileSpec.swift; sourceTree = "<group>"; };
 		137AAB441A3C0F3F0092F8A5 /* KeyRepeatTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyRepeatTimer.swift; sourceTree = "<group>"; };
+		137B0FC11ABD257600AF08F0 /* DictionaryEngineSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryEngineSpec.swift; sourceTree = "<group>"; };
 		138866981A09202500B7D8A4 /* SKKDictionaryEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionaryEntry.swift; sourceTree = "<group>"; };
 		138968CD1A85E2F400614511 /* SKKEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKEngine.swift; sourceTree = "<group>"; };
 		138968D01A85ED7300614511 /* ComposeMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeMode.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 			children = (
 				136610C81AA034BF006AA8F1 /* KeyHandler */,
 				135A44BC1A88203E0089F84E /* ComposeModePresenterSpec.swift */,
+				137B0FC11ABD257600AF08F0 /* DictionaryEngineSpec.swift */,
 			);
 			name = SKKEngine;
 			sourceTree = "<group>";
@@ -976,6 +979,7 @@
 				13DFEACA19F07AC8006D7E40 /* SKKLocalDictionaryFile.swift in Sources */,
 				13F9326F19E2DC1700AC5019 /* KeyButtonFlickPopup.swift in Sources */,
 				13A454FC19E2DAC30039390A /* UtilitiesSpec.swift in Sources */,
+				137B0FC21ABD257600AF08F0 /* DictionaryEngineSpec.swift in Sources */,
 				13F9325819E2DBFC00AC5019 /* Utilities.swift in Sources */,
 				136610C71AA0344A006AA8F1 /* KeyHandlerWordRegisterWithKanaComposeSpec.swift in Sources */,
 				138968D91A85F42200614511 /* ComposeMode.swift in Sources */,

--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		138EB8601A9035D300CB16BC /* Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138EB85E1A9035D300CB16BC /* Appearance.swift */; };
 		138EB8611A9035D300CB16BC /* Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138EB85E1A9035D300CB16BC /* Appearance.swift */; };
 		13A454FC19E2DAC30039390A /* UtilitiesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A454FB19E2DAC30039390A /* UtilitiesSpec.swift */; };
+		13B824811ABCE8E600F13FC3 /* Candidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B824801ABCE8E600F13FC3 /* Candidate.swift */; };
+		13B824821ABCE8E600F13FC3 /* Candidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B824801ABCE8E600F13FC3 /* Candidate.swift */; };
 		13D118CD19D99923009E9E79 /* skk.jisyo in Resources */ = {isa = PBXBuildFile; fileRef = 13D118C719D99923009E9E79 /* skk.jisyo */; };
 		13D118D019D9994D009E9E79 /* SKKDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D118CE19D9994D009E9E79 /* SKKDictionary.swift */; };
 		13DFEABA19F079C5006D7E40 /* SKKDictionaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DFEAB919F079C5006D7E40 /* SKKDictionaryFile.swift */; };
@@ -213,6 +215,7 @@
 		138968D01A85ED7300614511 /* ComposeMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeMode.swift; sourceTree = "<group>"; };
 		138EB85E1A9035D300CB16BC /* Appearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		13A454FB19E2DAC30039390A /* UtilitiesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilitiesSpec.swift; sourceTree = "<group>"; };
+		13B824801ABCE8E600F13FC3 /* Candidate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Candidate.swift; sourceTree = "<group>"; };
 		13D118C719D99923009E9E79 /* skk.jisyo */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = skk.jisyo; sourceTree = "<group>"; };
 		13D118CE19D9994D009E9E79 /* SKKDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionary.swift; sourceTree = "<group>"; };
 		13DFEAB919F079C5006D7E40 /* SKKDictionaryFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionaryFile.swift; sourceTree = "<group>"; };
@@ -431,13 +434,9 @@
 		138968C41A85E2BE00614511 /* SKKEngine */ = {
 			isa = PBXGroup;
 			children = (
+				13B824831ABCE90400F13FC3 /* ComposeMode */,
+				13B824841ABCE92300F13FC3 /* Component */,
 				138968CD1A85E2F400614511 /* SKKEngine.swift */,
-				138968D01A85ED7300614511 /* ComposeMode.swift */,
-				13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */,
-				1306495A1A871FEE0044B225 /* KeyHandler.swift */,
-				13E33E841A9E87CA00CD1140 /* TextEngine.swift */,
-				135A44B91A881F070089F84E /* ComposeModePresenter.swift */,
-				13E33E7D1A9E855500CD1140 /* DictionaryEngine.swift */,
 			);
 			name = SKKEngine;
 			sourceTree = "<group>";
@@ -449,6 +448,27 @@
 				135A44BC1A88203E0089F84E /* ComposeModePresenterSpec.swift */,
 			);
 			name = SKKEngine;
+			sourceTree = "<group>";
+		};
+		13B824831ABCE90400F13FC3 /* ComposeMode */ = {
+			isa = PBXGroup;
+			children = (
+				13B824801ABCE8E600F13FC3 /* Candidate.swift */,
+				138968D01A85ED7300614511 /* ComposeMode.swift */,
+				13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */,
+			);
+			name = ComposeMode;
+			sourceTree = "<group>";
+		};
+		13B824841ABCE92300F13FC3 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				1306495A1A871FEE0044B225 /* KeyHandler.swift */,
+				13E33E841A9E87CA00CD1140 /* TextEngine.swift */,
+				135A44B91A881F070089F84E /* ComposeModePresenter.swift */,
+				13E33E7D1A9E855500CD1140 /* DictionaryEngine.swift */,
+			);
+			name = Component;
 			sourceTree = "<group>";
 		};
 		13DFEAC319F079C8006D7E40 /* SKKDictionary */ = {
@@ -946,6 +966,7 @@
 				13F9326B19E2DC1700AC5019 /* KeyboardViewController.swift in Sources */,
 				136610BF1AA01451006AA8F1 /* KeyHandlerBaseSpec.swift in Sources */,
 				13DFEAC919F07AC6006D7E40 /* SKKUserDictionaryFile.swift in Sources */,
+				13B824811ABCE8E600F13FC3 /* Candidate.swift in Sources */,
 				13E33E851A9E87CA00CD1140 /* TextEngine.swift in Sources */,
 				13F9326E19E2DC1700AC5019 /* KeyButton.swift in Sources */,
 				13DFEACA19F07AC8006D7E40 /* SKKLocalDictionaryFile.swift in Sources */,
@@ -964,6 +985,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				13B824821ABCE8E600F13FC3 /* Candidate.swift in Sources */,
 				EAD4B59919D80AF3007B6636 /* Utilities.swift in Sources */,
 				137AAB451A3C0F3F0092F8A5 /* KeyRepeatTimer.swift in Sources */,
 				13DFEAC819F07A54006D7E40 /* SKKLocalDictionaryFile.swift in Sources */,

--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		13B824821ABCE8E600F13FC3 /* Candidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B824801ABCE8E600F13FC3 /* Candidate.swift */; };
 		13D118CD19D99923009E9E79 /* skk.jisyo in Resources */ = {isa = PBXBuildFile; fileRef = 13D118C719D99923009E9E79 /* skk.jisyo */; };
 		13D118D019D9994D009E9E79 /* SKKDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D118CE19D9994D009E9E79 /* SKKDictionary.swift */; };
+		13D9B7711ABD191500E63F33 /* SKKDictionarySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D9B7701ABD191500E63F33 /* SKKDictionarySpec.swift */; };
 		13DFEABA19F079C5006D7E40 /* SKKDictionaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DFEAB919F079C5006D7E40 /* SKKDictionaryFile.swift */; };
 		13DFEAC419F07A1F006D7E40 /* SKKDictionaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DFEAB919F079C5006D7E40 /* SKKDictionaryFile.swift */; };
 		13DFEAC619F07A3C006D7E40 /* SKKUserDictionaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DFEAC519F07A3C006D7E40 /* SKKUserDictionaryFile.swift */; };
@@ -218,6 +219,7 @@
 		13B824801ABCE8E600F13FC3 /* Candidate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Candidate.swift; sourceTree = "<group>"; };
 		13D118C719D99923009E9E79 /* skk.jisyo */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = skk.jisyo; sourceTree = "<group>"; };
 		13D118CE19D9994D009E9E79 /* SKKDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionary.swift; sourceTree = "<group>"; };
+		13D9B7701ABD191500E63F33 /* SKKDictionarySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionarySpec.swift; sourceTree = "<group>"; };
 		13DFEAB919F079C5006D7E40 /* SKKDictionaryFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKDictionaryFile.swift; sourceTree = "<group>"; };
 		13DFEAC519F07A3C006D7E40 /* SKKUserDictionaryFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKUserDictionaryFile.swift; sourceTree = "<group>"; };
 		13DFEAC719F07A54006D7E40 /* SKKLocalDictionaryFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKKLocalDictionaryFile.swift; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 			children = (
 				1341A24819E96A7F00EE8AFA /* SKKDictionaryLocalFileSpec.swift */,
 				136F409819E9D5ED009E3983 /* SKKDictionaryUserFileSpec.swift */,
+				13D9B7701ABD191500E63F33 /* SKKDictionarySpec.swift */,
 			);
 			name = SKKDictionary;
 			sourceTree = "<group>";
@@ -967,6 +970,7 @@
 				136610BF1AA01451006AA8F1 /* KeyHandlerBaseSpec.swift in Sources */,
 				13DFEAC919F07AC6006D7E40 /* SKKUserDictionaryFile.swift in Sources */,
 				13B824811ABCE8E600F13FC3 /* Candidate.swift in Sources */,
+				13D9B7711ABD191500E63F33 /* SKKDictionarySpec.swift in Sources */,
 				13E33E851A9E87CA00CD1140 /* TextEngine.swift in Sources */,
 				13F9326E19E2DC1700AC5019 /* KeyButton.swift in Sources */,
 				13DFEACA19F07AC8006D7E40 /* SKKLocalDictionaryFile.swift in Sources */,

--- a/FlickSKK/Info.plist
+++ b/FlickSKK/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/FlickSKK/Info.plist
+++ b/FlickSKK/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/FlickSKKKeyboard/Candidate.swift
+++ b/FlickSKKKeyboard/Candidate.swift
@@ -1,13 +1,13 @@
 enum Candidate : Equatable {
-    case Abbrev(kanji: String, kana: String)
-    case Original(kanji : String)
+    case Partial(kanji: String, kana: String)
+    case Exact(kanji : String)
 }
 
 func ==(l : Candidate, r : Candidate) -> Bool {
     switch (l,r)  {
-    case let (.Abbrev(kanji: kanji1, kana: kana1), .Abbrev(kanji: kanji2, kana: kana2)):
+    case let (.Partial(kanji: kanji1, kana: kana1), .Partial(kanji: kanji2, kana: kana2)):
         return kanji1 == kanji2 && kana1 == kana2
-    case let (.Original(kanji: kanji1), .Original(kanji: kanji2)):
+    case let (.Exact(kanji: kanji1), .Exact(kanji: kanji2)):
         return kanji1 == kanji2
     default:
         return false

--- a/FlickSKKKeyboard/Candidate.swift
+++ b/FlickSKKKeyboard/Candidate.swift
@@ -1,0 +1,15 @@
+enum Candidate : Equatable {
+    case Abbrev(kanji: String, kana: String)
+    case Original(kanji : String)
+}
+
+func ==(l : Candidate, r : Candidate) -> Bool {
+    switch (l,r)  {
+    case let (.Abbrev(kanji: kanji1, kana: kana1), .Abbrev(kanji: kanji2, kana: kana2)):
+        return kanji1 == kanji2 && kana1 == kana2
+    case let (.Original(kanji: kanji1), .Original(kanji: kanji2)):
+        return kanji1 == kanji2
+    default:
+        return false
+    }
+}

--- a/FlickSKKKeyboard/ComposeMode.swift
+++ b/FlickSKKKeyboard/ComposeMode.swift
@@ -8,8 +8,8 @@
 
 enum ComposeMode {
     case DirectInput
-    case KanaCompose(kana : String, candidates: [String])
-    case KanjiCompose(kana : String, okuri : String?, candidates: [String], index : Int)
+    case KanaCompose(kana : String, candidates: [Candidate])
+    case KanjiCompose(kana : String, okuri : String?, candidates: [Candidate], index : Int)
     case WordRegister(kana : String, okuri : String?, composeText : String, composeMode : [ComposeMode])
 }
 

--- a/FlickSKKKeyboard/ComposeModeFactory.swift
+++ b/FlickSKKKeyboard/ComposeModeFactory.swift
@@ -6,12 +6,12 @@ class ComposeModeFactory {
     }
 
     func kanaCompose(kana : String) -> ComposeMode {
-        let candidates = dictionary.find(kana, okuri: nil, aggresive: kana.utf16Count > 1)
+        let candidates = dictionary.find(kana, okuri: nil, dynamic: kana.utf16Count > 1)
         return .KanaCompose(kana : kana, candidates: candidates)
     }
 
     func kanjiCompose(kana : String, okuri : String?) -> ComposeMode {
-        let candidates = dictionary.find(kana, okuri: okuri, aggresive: false)
+        let candidates = dictionary.find(kana, okuri: okuri, dynamic: false)
         if candidates.isEmpty {
             return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
         } else {

--- a/FlickSKKKeyboard/ComposeModeFactory.swift
+++ b/FlickSKKKeyboard/ComposeModeFactory.swift
@@ -6,11 +6,12 @@ class ComposeModeFactory {
     }
 
     func kanaCompose(kana : String) -> ComposeMode {
-        return .KanaCompose(kana : kana, candidates: dictionary.find(kana, okuri: nil))
+        let candidates = dictionary.find(kana, okuri: nil, aggresive: kana.utf16Count > 1)
+        return .KanaCompose(kana : kana, candidates: candidates)
     }
 
     func kanjiCompose(kana : String, okuri : String?) -> ComposeMode {
-        let candidates = dictionary.find(kana, okuri: okuri)
+        let candidates = dictionary.find(kana, okuri: okuri, aggresive: false)
         if candidates.isEmpty {
             return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
         } else {

--- a/FlickSKKKeyboard/ComposeModeFactory.swift
+++ b/FlickSKKKeyboard/ComposeModeFactory.swift
@@ -11,7 +11,7 @@ class ComposeModeFactory {
     }
 
     func kanjiCompose(kana : String, okuri : String?) -> ComposeMode {
-        let candidates = dictionary.find(kana, okuri: okuri, dynamic: false)
+        let candidates = dictionary.find(kana, okuri: okuri, dynamic: kana.utf16Count > 1)
         if candidates.isEmpty {
             return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
         } else {

--- a/FlickSKKKeyboard/ComposeModePresenter.swift
+++ b/FlickSKKKeyboard/ComposeModePresenter.swift
@@ -47,9 +47,9 @@ class ComposeModePresenter {
 
     private func fromCandidate(candidate : Candidate) -> String {
         switch candidate {
-        case .Abbrev(kanji: let kanji, kana: _):
+        case .Partial(kanji: let kanji, kana: _):
             return "#\(kanji)"
-        case .Original(kanji: let kanji):
+        case .Exact(kanji: let kanji):
             return kanji
         }
     }

--- a/FlickSKKKeyboard/ComposeModePresenter.swift
+++ b/FlickSKKKeyboard/ComposeModePresenter.swift
@@ -8,7 +8,7 @@ class ComposeModePresenter {
         case .KanaCompose(kana: let kana, candidates: _):
             return "▽\(kana)"
         case .KanjiCompose(kana: _, okuri: _, candidates: let candidates, index: let index):
-            return "▼\(candidates[index])"
+            return "▼\(fromCandidate(candidates[index]))"
         case .WordRegister(kana : let kana, okuri : let okuri, composeText : let text, composeMode : let m):
             let prefix = kana + (okuri.map({ str in "*" + str }) ?? "")
             let nested = toString(m[0]) ?? ""
@@ -22,9 +22,9 @@ class ComposeModePresenter {
         case .DirectInput:
             return .None
         case .KanaCompose(kana: _, candidates: let candidates):
-            return (candidates, .None)
+            return (candidates.map(fromCandidate), .None)
         case .KanjiCompose(kana: _, okuri: _, candidates: let candidates, index: let index):
-            return (candidates, index)
+            return (candidates.map(fromCandidate), index)
         case .WordRegister(kana : _, okuri : _, composeText : _, composeMode : let m):
             return candidates(m[0])
         }
@@ -42,6 +42,15 @@ class ComposeModePresenter {
         case .WordRegister(kana : _, okuri : _, composeText : _, composeMode : let m):
             return inStatusShowsCandidatesBySpace(m[0]
             )
+        }
+    }
+
+    private func fromCandidate(candidate : Candidate) -> String {
+        switch candidate {
+        case .Abbrev(kanji: let kanji, kana: _):
+            return "#\(kanji)"
+        case .Original(kanji: let kanji):
+            return kanji
         }
     }
 }

--- a/FlickSKKKeyboard/DictionaryCache.swift
+++ b/FlickSKKKeyboard/DictionaryCache.swift
@@ -16,8 +16,8 @@ class DictionaryCache {
     // ユーザごとに作られる辞書をロードする(例: 単語登録結果、学習結果)
     func loadUserDicitonary(path: String, closure: String -> SKKUserDictionaryFile) -> SKKUserDictionaryFile {
         if let mtime = getModifiedTime(path) {
-            if let (original, file) = kCache[path] {
-                if original == mtime {
+            if let (Exact, file) = kCache[path] {
+                if Exact == mtime {
                     // キャッシュが有効
                     NSLog("%@ is cached", path)
                     return file

--- a/FlickSKKKeyboard/DictionaryEngine.swift
+++ b/FlickSKKKeyboard/DictionaryEngine.swift
@@ -16,7 +16,7 @@ class DictionaryEngine {
 
     // 辞書を検索する。
     //  ・ っの特殊ルール等を考慮する
-    func find(kana : String, okuri : String?, aggresive: Bool) -> [Candidate] {
+    func find(kana : String, okuri : String?, dynamic: Bool) -> [Candidate] {
         // 結果をストアする
         var candidates : [Candidate] = []
 
@@ -24,8 +24,8 @@ class DictionaryEngine {
         let (t, roman) = normalize(kana, okuri: okuri)
 
         // アグレッシブ変換
-        if aggresive {
-            for candidate in self.dictionary.findAggresive(kana) {
+        if dynamic {
+            for candidate in self.dictionary.findDynamic(kana) {
                 candidates.append(.Abbrev(kanji: candidate.kanji, kana: candidate.kana))
             }
         }

--- a/FlickSKKKeyboard/DictionaryEngine.swift
+++ b/FlickSKKKeyboard/DictionaryEngine.swift
@@ -32,7 +32,7 @@ class DictionaryEngine {
 
         // 通常の検索をする
         for candidate in self.dictionary.find(t, okuri: roman) {
-            candidates.append(.Original(kanji: candidate))
+            candidates.append(.Original(kanji: candidate + (okuri ?? "")))
         }
 
         // 末尾が「っ」の場合は、変換位置を1つ前にする

--- a/FlickSKKKeyboard/DictionaryEngine.swift
+++ b/FlickSKKKeyboard/DictionaryEngine.swift
@@ -14,6 +14,15 @@ class DictionaryEngine {
         self.dictionary.learn(k, okuri: o, kanji: kanji)
     }
 
+    // q-確定の結果を学習する
+    func abbrev(kana: String, kanji: String) {
+        // 正規化する
+        let (k, _) = normalize(kana, okuri: nil)
+
+        // 学習する
+        self.dictionary.abbrev(k, okuri: nil, kanji: kanji)
+    }
+
     // 辞書を検索する。
     //  ・ っの特殊ルール等を考慮する
     func find(kana : String, okuri : String?, dynamic: Bool) -> [Candidate] {

--- a/FlickSKKKeyboard/DictionaryEngine.swift
+++ b/FlickSKKKeyboard/DictionaryEngine.swift
@@ -15,12 +15,12 @@ class DictionaryEngine {
     }
 
     // q-確定の結果を学習する
-    func abbrev(kana: String, kanji: String) {
+    func partial(kana: String, kanji: String) {
         // 正規化する
         let (k, _) = normalize(kana, okuri: nil)
 
         // 学習する
-        self.dictionary.abbrev(k, okuri: nil, kanji: kanji)
+        self.dictionary.partial(k, okuri: nil, kanji: kanji)
     }
 
     // 辞書を検索する。
@@ -35,13 +35,13 @@ class DictionaryEngine {
         // アグレッシブ変換
         if dynamic {
             for candidate in self.dictionary.findDynamic(kana) {
-                candidates.append(.Abbrev(kanji: candidate.kanji, kana: candidate.kana))
+                candidates.append(.Partial(kanji: candidate.kanji, kana: candidate.kana))
             }
         }
 
         // 通常の検索をする
         for candidate in self.dictionary.find(t, okuri: roman) {
-            candidates.append(.Original(kanji: candidate + (okuri ?? "")))
+            candidates.append(.Exact(kanji: candidate + (okuri ?? "")))
         }
 
         // 末尾が「っ」の場合は、変換位置を1つ前にする
@@ -49,7 +49,7 @@ class DictionaryEngine {
             // 「っ」送り仮名の場合の特殊処理
             // https://github.com/codefirst/FlickSKK/issues/27
             for candidate in self.dictionary.find(t.butLast(), okuri: roman) {
-                candidates.append(.Original(kanji: candidate + "っ" + (okuri ?? "")))
+                candidates.append(.Exact(kanji: candidate + "っ" + (okuri ?? "")))
             }
         }
         return candidates

--- a/FlickSKKKeyboard/DictionarySettings.swift
+++ b/FlickSKKKeyboard/DictionarySettings.swift
@@ -25,6 +25,12 @@ class DictionarySettings {
             NSHomeDirectory().stringByAppendingPathComponent("Library/skk.learn.jisyo")
     }
 
+    // q確定の結果の学習
+    class func defaultAbbrevDictionaryPath() -> String {
+        return AppGroup.pathForResource("Library/skk.abbrev.jisyo") ??
+            NSHomeDirectory().stringByAppendingPathComponent("Library/abbrev")
+    }
+
     // 組込みの辞書(L辞書とか)
     class func defaultDicitonaryPath() -> String {
        // 辞書は必ず組込まれているはず

--- a/FlickSKKKeyboard/DictionarySettings.swift
+++ b/FlickSKKKeyboard/DictionarySettings.swift
@@ -26,9 +26,9 @@ class DictionarySettings {
     }
 
     // q確定の結果の学習
-    class func defaultAbbrevDictionaryPath() -> String {
-        return AppGroup.pathForResource("Library/skk.abbrev.jisyo") ??
-            NSHomeDirectory().stringByAppendingPathComponent("Library/abbrev")
+    class func defaultPartialDictionaryPath() -> String {
+        return AppGroup.pathForResource("Library/skk.partial.jisyo") ??
+            NSHomeDirectory().stringByAppendingPathComponent("Library/skk.partial.jisyo")
     }
 
     // 組込みの辞書(L辞書とか)

--- a/FlickSKKKeyboard/KeyHandler.swift
+++ b/FlickSKKKeyboard/KeyHandler.swift
@@ -61,7 +61,7 @@ class KeyHandler {
     }
 
     // ▽モード
-    private func kanaCompose(keyEvent : SKKKeyEvent, kana : String, candidates: [String], status: TextEngine.Status) -> ComposeMode? {
+    private func kanaCompose(keyEvent : SKKKeyEvent, kana : String, candidates: [Candidate], status: TextEngine.Status) -> ComposeMode? {
         switch keyEvent {
         case .Char(kana: let str, shift : let shift) where !shift:
             return factory.kanaCompose(kana + str)
@@ -99,7 +99,7 @@ class KeyHandler {
             return .DirectInput
         case .Select(index: let index):
             if index < candidates.count {
-                text.insert(candidates[index], learn: (kana, nil), status : status)
+                text.insertCandidate(candidates[index], learn: (kana, nil), status : status)
                 return .DirectInput
             } else {
                 return .WordRegister(kana : kana, okuri : .None, composeText: "", composeMode : [ .DirectInput ])
@@ -109,12 +109,12 @@ class KeyHandler {
 
     // ▼モード
     private func kanjiCompose(keyEvent : SKKKeyEvent,
-        kana : String, okuri : String?, candidates : [String], index : Int,
+        kana : String, okuri : String?, candidates : [Candidate], index : Int,
         status : TextEngine.Status) -> ComposeMode? {
         switch keyEvent {
         case .Char(kana: let str, shift : let shift):
             // 暗黙的に確定する。単語登録中の場合は、statusが更新されるので、次に引き渡す
-            let status = text.insert(candidates[index], learn: (kana, okuri), status : status)
+            let status = text.insertCandidate(candidates[index], learn: (kana, okuri), status : status)
             // 次の処理を開始する
             return self.dispatch(keyEvent, composeMode: .DirectInput, status: status)
         case .Space:
@@ -124,7 +124,7 @@ class KeyHandler {
                 return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])
             }
         case .Enter:
-            text.insert(candidates[index], learn: (kana, okuri), status : status)
+            text.insertCandidate(candidates[index], learn: (kana, okuri), status : status)
             return .DirectInput
         case .Backspace where index == 0:
             return factory.kanaCompose(kana)
@@ -147,7 +147,7 @@ class KeyHandler {
             return nil
         case .Select(index : let index):
             if index < candidates.count {
-                text.insert(candidates[index], learn: (kana, okuri), status : status)
+                text.insertCandidate(candidates[index], learn: (kana, okuri), status : status)
                 return .DirectInput
             } else {
                 return .WordRegister(kana : kana, okuri : okuri, composeText: "", composeMode : [ .DirectInput ])

--- a/FlickSKKKeyboard/KeyHandler.swift
+++ b/FlickSKKKeyboard/KeyHandler.swift
@@ -95,7 +95,7 @@ class KeyHandler {
             }
         case .InputModeChange(inputMode: let inputMode):
             let str = kana.conv(inputMode.kanaType())
-            text.insert(str, learn: nil, status : status)
+            text.insertAbbrev(str, kana: kana, status: status)
             return .DirectInput
         case .Select(index: let index):
             if index < candidates.count {

--- a/FlickSKKKeyboard/KeyHandler.swift
+++ b/FlickSKKKeyboard/KeyHandler.swift
@@ -95,7 +95,7 @@ class KeyHandler {
             }
         case .InputModeChange(inputMode: let inputMode):
             let str = kana.conv(inputMode.kanaType())
-            text.insertAbbrev(str, kana: kana, status: status)
+            text.insertPartial(str, kana: kana, status: status)
             return .DirectInput
         case .Select(index: let index):
             if index < candidates.count {

--- a/FlickSKKKeyboard/SKKDictionary.swift
+++ b/FlickSKKKeyboard/SKKDictionary.swift
@@ -17,7 +17,7 @@ class SKKDictionary : NSObject {
     private var learnDictionary : SKKUserDictionaryFile?
 
     // 略語辞書
-    private var abbrevDictionary : SKKUserDictionaryFile?
+    private var partialDictionary : SKKUserDictionaryFile?
 
     // ロード完了を監視するために Key value observing を使う
     dynamic var isWaitingForLoad : Bool = false
@@ -27,7 +27,7 @@ class SKKDictionary : NSObject {
     private let cache = DictionaryCache()
 
     class func resetLearnDictionary() {
-        for path in [DictionarySettings.defaultLearnDictionaryPath(), DictionarySettings.defaultAbbrevDictionaryPath()] {
+        for path in [DictionarySettings.defaultLearnDictionaryPath(), DictionarySettings.defaultPartialDictionaryPath()] {
             NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
         }
     }
@@ -47,13 +47,13 @@ class SKKDictionary : NSObject {
                 return SKKUserDictionaryFile(path: $0)
             }
 
-            self.abbrevDictionary =
-                self.cache.loadUserDicitonary(DictionarySettings.defaultAbbrevDictionaryPath()){
+            self.partialDictionary =
+                self.cache.loadUserDicitonary(DictionarySettings.defaultPartialDictionaryPath()){
                     return SKKUserDictionaryFile(path: $0)
             }
 
             self.dictionaries = [ self.learnDictionary!, self.userDictionary!, dictionary ]
-            self.dynamicDictionaries = [ self.abbrevDictionary!, self.learnDictionary!, self.userDictionary! ]
+            self.dynamicDictionaries = [ self.partialDictionary!, self.learnDictionary!, self.userDictionary! ]
         }
     }
 
@@ -102,11 +102,11 @@ class SKKDictionary : NSObject {
     }
 
     // InputModeChangeによる確定を学習する
-    func abbrev(kana: String, okuri: String?, kanji: String) {
-        abbrevDictionary?.register(kana, okuri: okuri, kanji: kanji)
+    func partial(kana: String, okuri: String?, kanji: String) {
+        partialDictionary?.register(kana, okuri: okuri, kanji: kanji)
         loader.async {
-            self.cache.update(DictionarySettings.defaultAbbrevDictionaryPath()) {
-                self.abbrevDictionary?.serialize()
+            self.cache.update(DictionarySettings.defaultPartialDictionaryPath()) {
+                self.partialDictionary?.serialize()
                 ()
             }
         }

--- a/FlickSKKKeyboard/SKKDictionary.swift
+++ b/FlickSKKKeyboard/SKKDictionary.swift
@@ -57,6 +57,14 @@ class SKKDictionary : NSObject {
         return xs
     }
 
+    // アグレッシブ変換用の辞書検索
+    func findAggresive(prefix : String) -> [(kana: String, kanji: String)] {
+        self.waitForLoading()
+        let xs = self.learnDictionary?.findWith(prefix) ?? []
+        let ys = self.userDictionary?.findWith(prefix) ?? []
+        return xs + ys
+    }
+
     // 単語を登録する
     func register(normal : String, okuri: String?, kanji: String) {
         userDictionary?.register(normal, okuri: okuri, kanji: kanji)

--- a/FlickSKKKeyboard/SKKDictionary.swift
+++ b/FlickSKKKeyboard/SKKDictionary.swift
@@ -7,11 +7,17 @@ class SKKDictionary : NSObject {
     // すべての辞書(先頭から順に検索される)
     private var dictionaries : [ SKKDictionaryFile ] = []
 
+    // ダイナミック変換用辞書
+    private var dynamicDictionaries : [ SKKUserDictionaryFile ] = []
+
     // ユーザ辞書
     private var userDictionary : SKKUserDictionaryFile?
 
     // 学習辞書
     private var learnDictionary : SKKUserDictionaryFile?
+
+    // 略語辞書
+    private var abbrevDictionary : SKKUserDictionaryFile?
 
     // ロード完了を監視するために Key value observing を使う
     dynamic var isWaitingForLoad : Bool = false
@@ -21,8 +27,9 @@ class SKKDictionary : NSObject {
     private let cache = DictionaryCache()
 
     class func resetLearnDictionary() {
-        let path = DictionarySettings.defaultLearnDictionaryPath()
-        NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
+        for path in [DictionarySettings.defaultLearnDictionaryPath(), DictionarySettings.defaultAbbrevDictionaryPath()] {
+            NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
+        }
     }
 
     override init() {
@@ -39,7 +46,14 @@ class SKKDictionary : NSObject {
                 self.cache.loadUserDicitonary(DictionarySettings.defaultLearnDictionaryPath()) {
                 return SKKUserDictionaryFile(path: $0)
             }
+
+            self.abbrevDictionary =
+                self.cache.loadUserDicitonary(DictionarySettings.defaultAbbrevDictionaryPath()){
+                    return SKKUserDictionaryFile(path: $0)
+            }
+
             self.dictionaries = [ self.learnDictionary!, self.userDictionary!, dictionary ]
+            self.dynamicDictionaries = [ self.abbrevDictionary!, self.learnDictionary!, self.userDictionary! ]
         }
     }
 
@@ -47,12 +61,9 @@ class SKKDictionary : NSObject {
     func find(normal : String, okuri : String?) -> [ String ] {
         self.waitForLoading()
 
-        let xs : [String] = self.dictionaries.map({(dict : SKKDictionaryFile) -> [String] in
-            dict.find(normal, okuri: okuri)
-        }).reduce([],
-                  combine: {(x : [String], y : [String]) -> [String] in
-            x + y
-        }).unique()
+        let xs : [String] = self.dictionaries.map {
+            $0.find(normal, okuri: okuri)
+        }.reduce([], +).unique()
 
         return xs
     }
@@ -60,9 +71,12 @@ class SKKDictionary : NSObject {
     // アグレッシブ変換用の辞書検索
     func findDynamic(prefix : String) -> [(kana: String, kanji: String)] {
         self.waitForLoading()
-        let xs = self.learnDictionary?.findWith(prefix) ?? []
-        let ys = self.userDictionary?.findWith(prefix) ?? []
-        return (xs + ys).uniqueBy { x in x.kanji }
+
+        let xs : [(kana : String, kanji: String)] = self.dynamicDictionaries.map {
+            $0.findWith(prefix)
+        }.reduce([], +).uniqueBy { c in c.kanji }
+
+        return xs
     }
 
     // 単語を登録する
@@ -82,6 +96,17 @@ class SKKDictionary : NSObject {
         loader.async {
             self.cache.update(DictionarySettings.defaultLearnDictionaryPath()) {
                 self.learnDictionary?.serialize()
+                ()
+            }
+        }
+    }
+
+    // InputModeChangeによる確定を学習する
+    func abbrev(kana: String, okuri: String?, kanji: String) {
+        abbrevDictionary?.register(kana, okuri: okuri, kanji: kanji)
+        loader.async {
+            self.cache.update(DictionarySettings.defaultAbbrevDictionaryPath()) {
+                self.abbrevDictionary?.serialize()
                 ()
             }
         }

--- a/FlickSKKKeyboard/SKKDictionary.swift
+++ b/FlickSKKKeyboard/SKKDictionary.swift
@@ -58,7 +58,7 @@ class SKKDictionary : NSObject {
     }
 
     // アグレッシブ変換用の辞書検索
-    func findAggresive(prefix : String) -> [(kana: String, kanji: String)] {
+    func findDynamic(prefix : String) -> [(kana: String, kanji: String)] {
         self.waitForLoading()
         let xs = self.learnDictionary?.findWith(prefix) ?? []
         let ys = self.userDictionary?.findWith(prefix) ?? []

--- a/FlickSKKKeyboard/SKKDictionary.swift
+++ b/FlickSKKKeyboard/SKKDictionary.swift
@@ -62,7 +62,7 @@ class SKKDictionary : NSObject {
         self.waitForLoading()
         let xs = self.learnDictionary?.findWith(prefix) ?? []
         let ys = self.userDictionary?.findWith(prefix) ?? []
-        return xs + ys
+        return (xs + ys).uniqueBy { x in x.kanji }
     }
 
     // 単語を登録する

--- a/FlickSKKKeyboard/SKKUserDictionaryFile.swift
+++ b/FlickSKKKeyboard/SKKUserDictionaryFile.swift
@@ -81,6 +81,20 @@ class SKKUserDictionaryFile  : SKKDictionaryFile {
         }
     }
 
+    func findWith(prefix: String) -> [(kana: String, kanji: String)] {
+        var xs : [(kana: String, kanji: String)] = []
+        for (normal, entry) in self.okuriNasi {
+            let n = normal as String
+            if n.hasPrefix(prefix) && n != prefix {
+                let parser = EntryParser(entry: (entry as String))
+                for word in parser.words() {
+                    xs.append(kana : n, kanji: word)
+                }
+            }
+        }
+        return xs
+    }
+
     func register(normal : String, okuri: String?, kanji: String) {
         if(kanji.isEmpty) { return }
         let dict : NSMutableDictionary = dictFor(okuri)

--- a/FlickSKKKeyboard/TextEngine.swift
+++ b/FlickSKKKeyboard/TextEngine.swift
@@ -19,9 +19,13 @@ class TextEngine {
 
     // テキストを確定させる。 learnを指定していれば、変換結果の学習も行なう。
     func insertCandidate(candidate : Candidate, learn : (String, String?)?, status : Status) -> Status {
-        let text = self.text(candidate)
         learnText(learn, candidate: candidate)
-        return insertText(candidate, status : status)
+        return insertText(text(candidate), status : status)
+    }
+
+    func insertAbbrev(kanji : String, kana: String, status : Status) -> Status {
+        dictionary.abbrev(kana, kanji: kanji)
+        return insertText(kanji, status: status)
     }
 
     func insert(text : String, learn : (String, String?)?, status : Status) -> Status {
@@ -69,8 +73,7 @@ class TextEngine {
         }
     }
 
-    private func insertText(candidate : Candidate, status : Status) -> Status {
-        let text = self.text(candidate)
+    private func insertText(text : String, status : Status) -> Status {
         switch status {
         case .TopLevel:
             self.delegate?.insertText(text)

--- a/FlickSKKKeyboard/TextEngine.swift
+++ b/FlickSKKKeyboard/TextEngine.swift
@@ -23,13 +23,13 @@ class TextEngine {
         return insertText(text(candidate), status : status)
     }
 
-    func insertAbbrev(kanji : String, kana: String, status : Status) -> Status {
-        dictionary.abbrev(kana, kanji: kanji)
+    func insertPartial(kanji : String, kana: String, status : Status) -> Status {
+        dictionary.partial(kana, kanji: kanji)
         return insertText(kanji, status: status)
     }
 
     func insert(text : String, learn : (String, String?)?, status : Status) -> Status {
-        return insertCandidate(.Original(kanji: text), learn: learn, status: status)
+        return insertCandidate(.Exact(kanji: text), learn: learn, status: status)
     }
 
     // 最後の一文字を消す
@@ -86,9 +86,9 @@ class TextEngine {
 
     private func text(candidate : Candidate) -> String {
         switch candidate {
-        case .Original(text: let text):
+        case .Exact(text: let text):
             return text
-        case .Abbrev(text: let text, original: _):
+        case .Partial(text: let text, Exact: _):
             return text
         }
     }
@@ -105,9 +105,9 @@ class TextEngine {
                 }
             }
             switch candidate {
-            case .Original(text: let text):
+            case .Exact(text: let text):
                 f(kana, text)
-            case .Abbrev(text: let text, orginal: let kana):
+            case .Partial(text: let text, orginal: let kana):
                 f(kana, text)
             }
         }

--- a/FlickSKKKeyboard/Utilities.swift
+++ b/FlickSKKKeyboard/Utilities.swift
@@ -465,12 +465,17 @@ extension String {
 
 extension Array {
     func unique <T: Hashable> () -> [T] {
-        var result = [T]()
+        return uniqueBy { x in x }
+    }
+
+    func uniqueBy <S, T: Hashable> (f : S -> T) -> [S] {
+        var result = [S]()
         var addedDict = [T: Bool]()
         for elem in self {
-            if addedDict[elem as T] == nil {
-                addedDict[elem as T] = true
-                result.append(elem as T)
+            let t : T = f(elem as S)
+            if addedDict[t as T] == nil {
+                addedDict[t as T] = true
+                result.append(elem as S)
             }
         }
         return result

--- a/FlickSKKTests/ComposeModePresenterSpec.swift
+++ b/FlickSKKTests/ComposeModePresenterSpec.swift
@@ -5,7 +5,7 @@ class ComposeModePresenterSpec : QuickSpec {
 
     override func spec() {
         let target = ComposeModePresenter()
-        let candidates : [Candidate] = [ .Original(kanji: "本気"), .Abbrev(kanji: "マジ", kana: "まじ") ]
+        let candidates : [Candidate] = [ .Exact(kanji: "本気"), .Partial(kanji: "マジ", kana: "まじ") ]
         describe("toString") {
             it("direct input") {
                 expect(target.toString(.DirectInput)).to(equal(""))

--- a/FlickSKKTests/ComposeModePresenterSpec.swift
+++ b/FlickSKKTests/ComposeModePresenterSpec.swift
@@ -5,15 +5,16 @@ class ComposeModePresenterSpec : QuickSpec {
 
     override func spec() {
         let target = ComposeModePresenter()
+        let candidates : [Candidate] = [ .Original(kanji: "本気"), .Abbrev(kanji: "マジ", kana: "まじ") ]
         describe("toString") {
             it("direct input") {
                 expect(target.toString(.DirectInput)).to(equal(""))
             }
             it("kana compose mode") {
-                expect(target.toString(.KanaCompose(kana: "こんにちは", candidates: ["foo", "bar"]))).to(equal("▽こんにちは"))
+                expect(target.toString(.KanaCompose(kana: "こんにちは", candidates: candidates))).to(equal("▽こんにちは"))
             }
             it("kanji compose mode") {
-                let m = ComposeMode.KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["本気"], index: 0)
+                let m = ComposeMode.KanjiCompose(kana: "ほんき", okuri: .None, candidates: candidates, index: 0)
                 expect(target.toString(m)).to(equal("▼本気"))
             }
             it("word register mode(direct)") {
@@ -36,15 +37,15 @@ class ComposeModePresenterSpec : QuickSpec {
                 expect(target.candidates(.DirectInput)).to(beNil())
             }
             it("kana compose mode") {
-                let c = target.candidates(.KanaCompose(kana: "こんにちは", candidates: ["foo", "bar"]))
-                expect(c?.candidates).to(equal(["foo", "bar"]))
+                let c = target.candidates(.KanaCompose(kana: "こんにちは", candidates: candidates))
+                expect(c?.candidates).to(equal(["本気", "#マジ"]))
                 expect(c?.index).to(beNil())
 
             }
             it("kanji compose mode") {
-                let m = ComposeMode.KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["foo", "bar"], index: 1)
+                let m = ComposeMode.KanjiCompose(kana: "ほんき", okuri: .None, candidates: candidates, index: 1)
                 let c = target.candidates(m)
-                expect(c?.candidates).to(equal(["foo", "bar"]))
+                expect(c?.candidates).to(equal(["本気", "#マジ"]))
                 expect(c?.index).to(equal(1))
 
             }
@@ -54,10 +55,10 @@ class ComposeModePresenterSpec : QuickSpec {
             }
             it("word register mode(kana compose)") {
                 let m = ComposeMode.WordRegister(kana: "ほんき", okuri: nil, composeText: "あ", composeMode: [
-                    .KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["foo", "bar"], index: 1)
+                    .KanjiCompose(kana: "ほんき", okuri: .None, candidates: candidates, index: 1)
                 ])
                 let (candidates, index) = target.candidates(m) ?? ([],0)
-                expect(candidates).to(equal(["foo", "bar"]))
+                expect(candidates).to(equal(["本気", "#マジ"]))
                 expect(index).to(equal(1))
             }
         }
@@ -68,11 +69,11 @@ class ComposeModePresenterSpec : QuickSpec {
                 expect(target.inStatusShowsCandidatesBySpace(.DirectInput)).to(beFalse())
             }
             it("kana compose mode") {
-                let ret = target.inStatusShowsCandidatesBySpace(.KanaCompose(kana: "こんにちは", candidates: ["foo", "bar"]))
+                let ret = target.inStatusShowsCandidatesBySpace(.KanaCompose(kana: "こんにちは", candidates: candidates))
                 expect(ret).to(beTrue())
             }
             it("kanji compose mode") {
-                let m = ComposeMode.KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["foo", "bar"], index: 1)
+                let m = ComposeMode.KanjiCompose(kana: "ほんき", okuri: .None, candidates: candidates, index: 1)
                 let ret = target.inStatusShowsCandidatesBySpace(m)
                 expect(ret).to(beTrue())
             }
@@ -83,7 +84,7 @@ class ComposeModePresenterSpec : QuickSpec {
             }
             it("word register mode(kana compose)") {
                 let m = ComposeMode.WordRegister(kana: "ほんき", okuri: nil, composeText: "あ", composeMode: [
-                    .KanjiCompose(kana: "ほんき", okuri: .None, candidates: ["foo", "bar"], index: 1)
+                    .KanjiCompose(kana: "ほんき", okuri: .None, candidates: candidates, index: 1)
                     ])
                 let ret = target.inStatusShowsCandidatesBySpace(m)
                 expect(ret).to(beTrue())

--- a/FlickSKKTests/DictionaryEngineSpec.swift
+++ b/FlickSKKTests/DictionaryEngineSpec.swift
@@ -1,0 +1,25 @@
+import Quick
+import Nimble
+
+class DictionaryEngineSpec : QuickSpec {
+    lazy var dictionary : SKKDictionary = {
+        DictionarySettings.bundle = NSBundle(forClass: self.classForCoder)
+        let dict = SKKDictionary()
+        dict.waitForLoading()
+        return dict
+        }()
+
+    override func spec() {
+        var dictionaryEngine : DictionaryEngine!
+
+        beforeEach {
+            dictionaryEngine = DictionaryEngine(dictionary: self.dictionary)
+        }
+
+        describe("#find") {
+            it("送り仮名を補う") {
+                let xs = dictionaryEngine.find("おく", okuri: "る", dynamic: false)
+            }
+        }
+    }
+}

--- a/FlickSKKTests/KeyHandlerBaseSpec.swift
+++ b/FlickSKKTests/KeyHandlerBaseSpec.swift
@@ -39,7 +39,11 @@ class KeyHandlerBaseSpec : QuickSpec {
         }
     }
 
-    func candidates(composeMode : ComposeMode) -> [String]? {
+    func originals(candidates: [String]) -> [Candidate] {
+        return candidates.map { c in .Original(kanji : c) }
+    }
+
+    func candidates(composeMode : ComposeMode) -> [Candidate]? {
         switch composeMode {
         case .KanjiCompose(kana: _, okuri: _, candidates: let candidates, index: _):
             return candidates

--- a/FlickSKKTests/KeyHandlerBaseSpec.swift
+++ b/FlickSKKTests/KeyHandlerBaseSpec.swift
@@ -39,8 +39,8 @@ class KeyHandlerBaseSpec : QuickSpec {
         }
     }
 
-    func originals(candidates: [String]) -> [Candidate] {
-        return candidates.map { c in .Original(kanji : c) }
+    func exacts(candidates: [String]) -> [Candidate] {
+        return candidates.map { c in .Exact(kanji : c) }
     }
 
     func candidates(composeMode : ComposeMode) -> [Candidate]? {

--- a/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
@@ -22,6 +22,23 @@ class KeyHandlerKanaComposeSpec : KeyHandlerBaseSpec {
                 expect(self.kana(m)).to(equal("かわら"))
             }
             describe("Space") {
+                it("partialな候補がある場合") {
+                    self.dictionary.partial("かわなんとか", okuri: .None, kanji: "カワナントカ")
+                    let m = handler.handle(.Space, composeMode: composeMode)
+                    let (kana, okuri) = self.kanji(m)!
+                    if let c = self.candidates(m)?[0] {
+                        switch c {
+                        case let .Partial(kanji: kanji, kana: _):
+                            expect(kanji).to(equal("カワナントカ"))
+                        default:
+                            fail()
+                        }
+
+                    } else {
+                        fail()
+                    }
+                }
+
                 it("単語がある場合") {
                     let m = handler.handle(.Space, composeMode: composeMode)
                     let (kana, okuri) = self.kanji(m)!

--- a/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
@@ -13,8 +13,10 @@ class KeyHandlerKanaComposeSpec : KeyHandlerBaseSpec {
             delegate = d
         }
 
+        let candidates = originals(["川", "河"])
+
         context("kana compose") {
-            let composeMode = ComposeMode.KanaCompose(kana: "かわ", candidates: ["川", "河"])
+            let composeMode = ComposeMode.KanaCompose(kana: "かわ", candidates: candidates)
             it("文字入力(シフトなし)") {
                 let m = handler.handle(.Char(kana: "ら", shift: false), composeMode: composeMode)
                 expect(self.kana(m)).to(equal("かわら"))

--- a/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
@@ -13,7 +13,7 @@ class KeyHandlerKanaComposeSpec : KeyHandlerBaseSpec {
             delegate = d
         }
 
-        let candidates = originals(["川", "河"])
+        let candidates = exacts(["川", "河"])
 
         context("kana compose") {
             let composeMode = ComposeMode.KanaCompose(kana: "かわ", candidates: candidates)

--- a/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanaComposeSpec.swift
@@ -70,6 +70,14 @@ class KeyHandlerKanaComposeSpec : KeyHandlerBaseSpec {
                 expect(m == .DirectInput).to(beTrue())
                 expect(delegate.insertedText).to(equal("カワ"))
             }
+            it("略語学習") {
+                let composeMode = ComposeMode.KanaCompose(kana: "はなやまた", candidates: candidates)
+                let m = handler.handle(.InputModeChange(inputMode : .Katakana), composeMode: composeMode)
+                let xs = self.dictionary.findDynamic("はなや").filter { w in
+                    w.kanji == "ハナヤマタ"
+                }
+                expect(xs.count).to(equal(1))
+            }
             describe("シフトあり文字入力") {
                 it("単語がある場合") {
                     let m = handler.handle(.Char(kana: "い", shift: true), composeMode: composeMode)

--- a/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
@@ -13,8 +13,11 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
             delegate = d
         }
 
+        let candidates = originals(["川", "河"])
+        let candidatesWithOkuri = originals(["居る", "入る"])
+
         context("kanji compose") {
-            let composeMode = ComposeMode.KanjiCompose(kana: "かわ", okuri: .None, candidates: ["川", "河"], index: 0)
+            let composeMode = ComposeMode.KanjiCompose(kana: "かわ", okuri: .None, candidates: candidates, index: 0)
 
             it("文字入力(シフトなし)") {
                 let m = handler.handle(.Char(kana: "に", shift: false), composeMode: composeMode)
@@ -32,14 +35,15 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                     expect(self.index(m)).to(equal(1))
                 }
                 it("送り仮名がある場合") {
-                    let m = handler.handle(.Space, composeMode: ComposeMode.KanjiCompose(kana: "い", okuri: "る", candidates: ["居る", "入る"], index: 0))
+                    let m = handler.handle(.Space, composeMode: ComposeMode.KanjiCompose(kana: "い", okuri: "る",
+                        candidates: candidatesWithOkuri, index: 0))
                     let (kana, okuri) = self.kanji(m)!
                     expect(kana).to(equal("い"))
                     expect(okuri).to(equal("る"))
                     expect(self.index(m)).to(equal(1))
                 }
                 it("単語がない場合") {
-                    let m = handler.handle(.Space, composeMode: .KanjiCompose(kana: "かわ", okuri: .None, candidates: ["川", "河"], index: 1))
+                    let m = handler.handle(.Space, composeMode: .KanjiCompose(kana: "かわ", okuri: .None, candidates: candidates, index: 1))
                     switch m {
                     case .WordRegister(kana: let kana, okuri: let okuri, composeText : let composeText, composeMode : let composeMode):
                         expect(kana).to(equal("かわ"))
@@ -64,7 +68,7 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                     expect(self.kana(m)).to(equal("かわ"))
                 }
                 it("index > 0") {
-                    let m = handler.handle(.Backspace, composeMode: ComposeMode.KanjiCompose(kana: "かわ", okuri: .None, candidates: ["川", "河"], index: 1))
+                    let m = handler.handle(.Backspace, composeMode: ComposeMode.KanjiCompose(kana: "かわ", okuri: .None, candidates: candidates, index: 1))
                     expect(self.index(m)).to(equal(0))
                 }
             }
@@ -75,7 +79,7 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                 let m = handler.handle(.ToggleDakuten(beforeText: ""),
                     composeMode: ComposeMode.KanjiCompose(kana: "さわ",
                         okuri: "き",
-                        candidates: ["foo","bar"], index: 1))
+                        candidates: candidates, index: 1))
                 let (kana, okuri) = self.kanji(m)!
                 expect(kana).to(equal("さわ"))
                 expect(okuri).to(equal("ぎ"))
@@ -118,7 +122,7 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                     expect(self.dictionary.find("かわ", okuri: nil)[0]).to(equal("川"))
                 }
                 it("送りあり") {
-                    let composeMode = ComposeMode.KanjiCompose(kana: "い", okuri: "る", candidates: ["入る", "居る"], index: 0)
+                    let composeMode = ComposeMode.KanjiCompose(kana: "い", okuri: "る", candidates: candidatesWithOkuri, index: 0)
                     let m = handler.handle(.Select(index: 1), composeMode: composeMode)
 
                     // 学習したものが先頭にくる
@@ -126,7 +130,7 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
                     expect(xs).notTo(beEmpty())
 
                     // 送り仮名は学習しない
-                    expect(xs[0]).to(equal("居"))
+                    expect(xs[0]).to(equal("入"))
                 }
             }
         }

--- a/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerKanjiComposeSpec.swift
@@ -13,8 +13,8 @@ class KeyHandlerKanjiComposeSpec : KeyHandlerBaseSpec {
             delegate = d
         }
 
-        let candidates = originals(["川", "河"])
-        let candidatesWithOkuri = originals(["居る", "入る"])
+        let candidates = exacts(["川", "河"])
+        let candidatesWithOkuri = exacts(["居る", "入る"])
 
         context("kanji compose") {
             let composeMode = ComposeMode.KanjiCompose(kana: "かわ", okuri: .None, candidates: candidates, index: 0)

--- a/FlickSKKTests/KeyHandlerWordRegisterWithKanaComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerWordRegisterWithKanaComposeSpec.swift
@@ -42,7 +42,7 @@ class KeyHandlerWordRegisterWithKanaComposeSpec : KeyHandlerBaseSpec {
 
         context("word register with kanji mode") {
             let composeMode = ComposeMode.WordRegister(kana: "まじ",
-                okuri: .None, composeText : "か", composeMode: [ .KanjiCompose(kana: "やま", okuri : .None, candidates: self.originals(["山"]), index: 0)])
+                okuri: .None, composeText : "か", composeMode: [ .KanjiCompose(kana: "やま", okuri : .None, candidates: self.exacts(["山"]), index: 0)])
             it("Enter") {
                 let m = handler.handle(.Enter, composeMode : composeMode)
                 switch m {

--- a/FlickSKKTests/KeyHandlerWordRegisterWithKanaComposeSpec.swift
+++ b/FlickSKKTests/KeyHandlerWordRegisterWithKanaComposeSpec.swift
@@ -42,7 +42,7 @@ class KeyHandlerWordRegisterWithKanaComposeSpec : KeyHandlerBaseSpec {
 
         context("word register with kanji mode") {
             let composeMode = ComposeMode.WordRegister(kana: "まじ",
-                okuri: .None, composeText : "か", composeMode: [ .KanjiCompose(kana: "やま", okuri : .None, candidates: ["山"], index: 0)])
+                okuri: .None, composeText : "か", composeMode: [ .KanjiCompose(kana: "やま", okuri : .None, candidates: self.originals(["山"]), index: 0)])
             it("Enter") {
                 let m = handler.handle(.Enter, composeMode : composeMode)
                 switch m {

--- a/FlickSKKTests/SKKDictionaryLocalFileSpec.swift
+++ b/FlickSKKTests/SKKDictionaryLocalFileSpec.swift
@@ -34,6 +34,7 @@ class SKKDictionaryLocalFileSpec : QuickSpec {
                 expect(xs).to(contain("一円"))
                 expect(xs).to(contain("1円"))
             }
+
         }
         describe("okuri-ari") {
             it("can find first entry"){

--- a/FlickSKKTests/SKKDictionarySpec.swift
+++ b/FlickSKKTests/SKKDictionarySpec.swift
@@ -1,0 +1,34 @@
+import Quick
+import Nimble
+
+class SKKDictionarySpec : QuickSpec {
+    lazy var dictionary : SKKDictionary = {
+        DictionarySettings.bundle = NSBundle(forClass: self.classForCoder)
+        let dict = SKKDictionary()
+        dict.waitForLoading()
+        return dict
+        }()
+
+    override func spec() {
+        describe("#findDynamic") {
+            it("重複して取得しない") {
+                self.dictionary.register("ほんき", okuri: nil, kanji: "本気")
+                self.dictionary.learn("ほんき", okuri: nil, kanji: "本気")
+                let xs = self.dictionary.findDynamic("ほん")
+                expect(xs.count).to(equal(1))
+                expect(xs[0].kanji).to(equal("本気"))
+                expect(xs[0].kana).to(equal("ほんき"))
+            }
+        }
+
+        describe("#find") {
+            it("重複して取得しない") {
+                self.dictionary.register("ほんき", okuri: nil, kanji: "本気")
+                let xs = self.dictionary.find("ほんき", okuri: nil).filter { w in
+                    w == "本気"
+                }
+                expect(xs.count).to(equal(1))
+            }
+        }
+    }
+}

--- a/FlickSKKTests/SKKDictionarySpec.swift
+++ b/FlickSKKTests/SKKDictionarySpec.swift
@@ -33,9 +33,9 @@ class SKKDictionarySpec : QuickSpec {
             }
         }
 
-        describe("#abbrev") {
+        describe("#partial") {
             beforeEach {
-                self.dictionary.abbrev("ほんき",  okuri: nil, kanji: "ホンキ")
+                self.dictionary.partial("ほんき",  okuri: nil, kanji: "ホンキ")
             }
 
             it("ダイナミック変換できる") {

--- a/FlickSKKTests/SKKDictionarySpec.swift
+++ b/FlickSKKTests/SKKDictionarySpec.swift
@@ -7,14 +7,16 @@ class SKKDictionarySpec : QuickSpec {
         let dict = SKKDictionary()
         dict.waitForLoading()
         return dict
-        }()
+    }()
 
     override func spec() {
         describe("#findDynamic") {
             it("重複して取得しない") {
                 self.dictionary.register("ほんき", okuri: nil, kanji: "本気")
                 self.dictionary.learn("ほんき", okuri: nil, kanji: "本気")
-                let xs = self.dictionary.findDynamic("ほん")
+                let xs = self.dictionary.findDynamic("ほん").filter { w in
+                    w.kanji == "本気"
+                }
                 expect(xs.count).to(equal(1))
                 expect(xs[0].kanji).to(equal("本気"))
                 expect(xs[0].kana).to(equal("ほんき"))
@@ -28,6 +30,22 @@ class SKKDictionarySpec : QuickSpec {
                     w == "本気"
                 }
                 expect(xs.count).to(equal(1))
+            }
+        }
+
+        describe("#abbrev") {
+            beforeEach {
+                self.dictionary.abbrev("ほんき",  okuri: nil, kanji: "ホンキ")
+            }
+
+            it("ダイナミック変換できる") {
+                let xs = self.dictionary.findDynamic("ほん")
+                expect(xs[0].kanji).to(equal("ホンキ"))
+            }
+
+            it("検索にはでてこない") {
+                let xs = self.dictionary.find("ほんき", okuri: nil)
+                expect(xs).toNot(contain("ホンキ"))
             }
         }
     }

--- a/FlickSKKTests/SKKDictionaryUserFileSpec.swift
+++ b/FlickSKKTests/SKKDictionaryUserFileSpec.swift
@@ -20,6 +20,22 @@ class SKKDictionaryUserFileSpec : QuickSpec {
                 dict = SKKUserDictionaryFile(path: path)
             }
 
+            describe("findWith") {
+                beforeEach {
+                    dict.register("まじ", okuri: .None, kanji: "本気")
+                }
+
+                it("前方一致で取得できる") {
+                    let x = dict.findWith("ま")[0]
+                    expect(x.kana).to(equal("まじ"))
+                    expect(x.kanji).to(equal("本気"))
+                }
+                it("完全一致では取得できない") {
+                    let xs = dict.findWith("まじ")
+                    expect(xs).to(beEmpty())
+                }
+            }
+
             describe("register") {
                 it("can find register entry") {
                     dict.register("まじ", okuri: .None, kanji: "本気")

--- a/FlickSKKTests/TextEngineSpec.swift
+++ b/FlickSKKTests/TextEngineSpec.swift
@@ -19,9 +19,9 @@ class TextEngineSpec : QuickSpec {
             target = TextEngine(delegate: delegate, dictionary: dictionaryEngine)
         }
 
-        describe("#insertAbbrev") {
+        describe("#insertPartial") {
             beforeEach {
-                target.insertAbbrev("ハナヤマタ", kana: "はなやまた", status: TextEngine.Status.TopLevel)
+                target.insertPartial("ハナヤマタ", kana: "はなやまた", status: TextEngine.Status.TopLevel)
                 ()
             }
 

--- a/FlickSKKTests/TextEngineSpec.swift
+++ b/FlickSKKTests/TextEngineSpec.swift
@@ -1,0 +1,38 @@
+import Quick
+import Nimble
+
+class TextEngineSpec : QuickSpec {
+    lazy var dictionary : SKKDictionary = {
+        DictionarySettings.bundle = NSBundle(forClass: self.classForCoder)
+        let dict = SKKDictionary()
+        dict.waitForLoading()
+        return dict
+    }()
+
+    override func spec() {
+        var target : TextEngine!
+        var delegate : MockDelegate!
+
+        beforeEach {
+            delegate = MockDelegate()
+            let dictionaryEngine = DictionaryEngine(dictionary: self.dictionary)
+            target = TextEngine(delegate: delegate, dictionary: dictionaryEngine)
+        }
+
+        describe("#insertAbbrev") {
+            beforeEach {
+                target.insertAbbrev("ハナヤマタ", kana: "はなやまた", status: TextEngine.Status.TopLevel)
+                ()
+            }
+
+            it("挿入される") {
+                expect(delegate.insertedText).to(equal("ハナヤマタ"))
+            }
+
+            it("補完できる") {
+                let xs = self.dictionary.findDynamic("はなや").filter { w in w.kanji == "ハナヤマタ" }
+                expect(xs.count).to(equal(1))
+            }
+        }
+    }
+}


### PR DESCRIPTION
タブ相当のキー入力はなにをつかうのか?

補完内容

* ユーザー辞書 (履歴) から
* 見出し語から?

## Known Issues

 * [x] 送り仮名入力できない
 * [x] ユーザー辞書と学習結果の両方の同じ単語が重複して表示される

## 検討したい
 * [x] カナ確定も覚えておいて補完してほしい
 * [x] 次候補で補完を捨てるのではなく，左から一個ずつ送りたい
 * [ ] 次候補の左フリックで，補完をスキップして通常の候補まで飛ばすとかのUI検討
 * [ ] 補完候補の表示UI検討したい (#で幅取りたくない。色を変えるとか？)
 * [x] 変な話，Abbrev, Original という名前が分かりづらい気がします

## 他
 * [ ] 二文字入力で表示は，いま使ってる範囲では良さそう
 * [ ] ダイナミック補完の候補の数に上限つけたほうがいいかも

