### PR TITLE
半角カナ入力モードでは記号も半角にする

### DIFF
--- a/FlickSKKKeyboard/KeyboardViewController.swift
+++ b/FlickSKKKeyboard/KeyboardViewController.swift
@@ -89,11 +89,11 @@ class KeyboardViewController: UIInputViewController, SKKDelegate {
                 seq("ﾅﾆﾇﾈﾉ"),
                 seq("ﾊﾋﾌﾍﾎ"),
                 seq("ﾏﾐﾑﾒﾓ"),
-                seq("ﾔ「ﾕ」ﾖ"),
+                seq("ﾔ｢ﾕ｣ﾖ"),
                 seq("ﾗﾘﾙﾚﾛ"),
                 .KomojiDakuten,
                 seq("ﾜｦﾝ-"),
-                seqWithSymbols("、。？！"),
+                seqWithSymbols("､｡?!"),
                 ]),
             .Number: KeyPad(keys: [
                 // よく使う記号(アルファベットキーにあわせた)


### PR DESCRIPTION
半角カナ入力モードでは鉤括弧や句読点も半角になってほしい気がするのですがどうでしょうか。