### PR TITLE
辞書のロードが完了してない間は、アグレッシブ・ダイナミック変換しないようにした

### DIFF
--- a/Common/SKKDictionary.swift
+++ b/Common/SKKDictionary.swift
@@ -136,6 +136,11 @@ class SKKDictionary : NSObject {
         self.isWaitingForLoad = false
     }
 
+    // 辞書ロードが完了しているかチェックする
+    func isInitialized() -> Bool {
+        return self.loader.initialized
+    }
+
     // ユーザ辞書を取得する(設定アプリ用)
     class func defaultUserDictionary() -> SKKUserDictionaryFile {
         let path = DictionarySettings.defaultUserDictionaryPath()

--- a/FlickSKKKeyboard/ComposeModeFactory.swift
+++ b/FlickSKKKeyboard/ComposeModeFactory.swift
@@ -6,7 +6,7 @@ class ComposeModeFactory {
     }
 
     func kanaCompose(kana : String) -> ComposeMode {
-        let candidates = dictionary.find(kana, okuri: nil, dynamic: count(kana.utf16) > 1)
+        let candidates = dictionary.peek(kana, okuri: nil, dynamic: count(kana.utf16) > 1)
         return .KanaCompose(kana : kana, candidates: candidates)
     }
 

--- a/FlickSKKKeyboard/DictionaryEngine.swift
+++ b/FlickSKKKeyboard/DictionaryEngine.swift
@@ -23,6 +23,15 @@ class DictionaryEngine {
         self.dictionary.partial(k, okuri: nil, kanji: kanji)
     }
 
+    // 辞書を検索するが、辞書ロードが完了していなければ空配列を返す
+    func peek(kana : String, okuri : String?, dynamic: Bool) -> [Candidate] {
+        if self.dictionary.isInitialized() {
+            return find(kana, okuri: okuri, dynamic: dynamic)
+        } else {
+            return []
+        }
+    }
+
     // 辞書を検索する。
     //  ・ っの特殊ルール等を考慮する
     func find(kana : String, okuri : String?, dynamic: Bool) -> [Candidate] {


### PR DESCRIPTION
起動直後に何か文字をいれると、辞書ロード完了まで待たされるのが若干ストレスです。

そこで、辞書ロードが完了してない間はアグレッシブ・ダイナミック変換をしないようにしてみましたがどうでしょう?