### PR TITLE
追加辞書画面を標準のキーボード追加画面のUIにあわせる

### DIFF
--- a/Common/ja.lproj/Localizable.strings
+++ b/Common/ja.lproj/Localizable.strings
@@ -17,13 +17,10 @@
 "Reset" = "リセット";
 "EnterWordRegister" = "▼単語登録";
 "Additional Dictionary" = "追加辞書";
-"HowToAddDictionary" = "現在、有効な辞書一覧です。削除は左スワイプで行なえます。";
-"UsefulDictionary" = "よく使われる辞書です。URL指定で任意の辞書を追加することもできます。";
-"LinkToOpenlab" = "SKK辞書はOpenlabで配布されています。 gzip圧縮された辞書には対応していないので、[閲覧]リンクを指定してください。";
-"URL" = "URL";
-"Download" = "追加";
-"OpenSKKDictWiki" = "Openlab SKK辞書Wikiを開く";
-"%d dictionaries registered" = "%d個の辞書が追加済み";
+"Add New Dictionary" = "辞書を追加";
+"Suggested Dictionary" = "推奨辞書";
+"Other Dictionary" = "その他の辞書";
+"Specify URL" = "URL指定";
 "DownloadError" = "ダウンロードに失敗しました";
 "EncodingError" = "未対応の文字エンコーディングです";
 "InvalidDictionary" = "辞書の形式が正しくありません";

--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -99,7 +99,7 @@
 		13787CF21B12110C00400A4A /* WordRegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131DBA8E1A42403100756CFA /* WordRegisterViewController.swift */; };
 		13787CF31B12110C00400A4A /* HeadUpProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C38FB01AFCEE61004CA747 /* HeadUpProgressViewController.swift */; };
 		13787CF41B12110C00400A4A /* AdditionalDictionaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135CDE681AF71843005C6CF0 /* AdditionalDictionaryViewController.swift */; };
-		13787CF51B12110C00400A4A /* DownloadDictionaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135CDE6A1AF71A56005C6CF0 /* DownloadDictionaryViewController.swift */; };
+		13787CF51B12110C00400A4A /* DicitonaryURLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135CDE6A1AF71A56005C6CF0 /* DicitonaryURLViewController.swift */; };
 		13787CF61B12110C00400A4A /* MainMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD4B56719D5CB50007B6636 /* MainMenuViewController.swift */; };
 		13787CF71B12110C00400A4A /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACD52A019F3F2EC001FB2A7 /* WebViewController.swift */; };
 		13787CF81B12110C00400A4A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD4B56519D5CB50007B6636 /* AppDelegate.swift */; };
@@ -136,6 +136,8 @@
 		13E33E851A9E87CA00CD1140 /* TextEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E841A9E87CA00CD1140 /* TextEngine.swift */; };
 		13E33E881A9E8E3D00CD1140 /* ComposeModeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */; };
 		13E566CC1AF6360300592844 /* BinarySearchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E566CB1AF6360300592844 /* BinarySearchSpec.swift */; };
+		13E86DCA1B49E5E100B327C4 /* SelectDictionaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E86DC91B49E5E100B327C4 /* SelectDictionaryViewController.swift */; };
+		13E86DCE1B49E71A00B327C4 /* AdditionalDictionaries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E86DCD1B49E71A00B327C4 /* AdditionalDictionaries.swift */; };
 		13F456381ADBD863004EB68D /* NumberFliterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F456371ADBD863004EB68D /* NumberFliterSpec.swift */; };
 		13F9326119E2DC1700AC5019 /* SKKDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133CDCF519D98A3B00B8120D /* SKKDelegate.swift */; };
 		13F9326419E2DC1700AC5019 /* SKKInputMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136D161019DAA0AE0091D6BF /* SKKInputMode.swift */; };
@@ -261,7 +263,7 @@
 		135A44B91A881F070089F84E /* ComposeModePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeModePresenter.swift; sourceTree = "<group>"; };
 		135A44BC1A88203E0089F84E /* ComposeModePresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeModePresenterSpec.swift; sourceTree = "<group>"; };
 		135CDE681AF71843005C6CF0 /* AdditionalDictionaryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdditionalDictionaryViewController.swift; sourceTree = "<group>"; };
-		135CDE6A1AF71A56005C6CF0 /* DownloadDictionaryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadDictionaryViewController.swift; sourceTree = "<group>"; };
+		135CDE6A1AF71A56005C6CF0 /* DicitonaryURLViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DicitonaryURLViewController.swift; sourceTree = "<group>"; };
 		136610B61AA00FFB006AA8F1 /* KeyHandlerDirectInputSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyHandlerDirectInputSpec.swift; sourceTree = "<group>"; };
 		136610BC1AA0100E006AA8F1 /* MockDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDelegate.swift; sourceTree = "<group>"; };
 		136610BE1AA01451006AA8F1 /* KeyHandlerBaseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyHandlerBaseSpec.swift; sourceTree = "<group>"; };
@@ -286,6 +288,8 @@
 		13E33E841A9E87CA00CD1140 /* TextEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextEngine.swift; sourceTree = "<group>"; };
 		13E33E871A9E8E3C00CD1140 /* ComposeModeFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeModeFactory.swift; sourceTree = "<group>"; };
 		13E566CB1AF6360300592844 /* BinarySearchSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinarySearchSpec.swift; sourceTree = "<group>"; };
+		13E86DC91B49E5E100B327C4 /* SelectDictionaryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectDictionaryViewController.swift; sourceTree = "<group>"; };
+		13E86DCD1B49E71A00B327C4 /* AdditionalDictionaries.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdditionalDictionaries.swift; sourceTree = "<group>"; };
 		13F456371ADBD863004EB68D /* NumberFliterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFliterSpec.swift; sourceTree = "<group>"; };
 		3758E2CE5E666333313C17EA /* Pods-FlickSKKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlickSKKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FlickSKKTests/Pods-FlickSKKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3927343C314CA30425B06CCA /* Pods-FlickSKK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlickSKK.release.xcconfig"; path = "Pods/Target Support Files/Pods-FlickSKK/Pods-FlickSKK.release.xcconfig"; sourceTree = "<group>"; };
@@ -595,7 +599,8 @@
 			children = (
 				13C38FB01AFCEE61004CA747 /* HeadUpProgressViewController.swift */,
 				135CDE681AF71843005C6CF0 /* AdditionalDictionaryViewController.swift */,
-				135CDE6A1AF71A56005C6CF0 /* DownloadDictionaryViewController.swift */,
+				13E86DC91B49E5E100B327C4 /* SelectDictionaryViewController.swift */,
+				135CDE6A1AF71A56005C6CF0 /* DicitonaryURLViewController.swift */,
 			);
 			name = AdditionalDictionary;
 			sourceTree = "<group>";
@@ -624,6 +629,7 @@
 		13C3EAB11B040BCC00DB4AD8 /* DownloadDictionary */ = {
 			isa = PBXGroup;
 			children = (
+				13E86DCD1B49E71A00B327C4 /* AdditionalDictionaries.swift */,
 				135182271B1224BA00774954 /* ValidateDictionary.swift */,
 				13B74CD41B040EC200EBA709 /* SortDictionary.swift */,
 				1302150C1AF7762500918E98 /* DownloadDictionary.swift */,
@@ -1141,10 +1147,11 @@
 				13787CF11B12110C00400A4A /* UserDictionaryViewController.swift in Sources */,
 				135181E01B12139000774954 /* BinarySearch.swift in Sources */,
 				13787CF21B12110C00400A4A /* WordRegisterViewController.swift in Sources */,
+				13E86DCE1B49E71A00B327C4 /* AdditionalDictionaries.swift in Sources */,
 				135181EF1B12139000774954 /* IOUtil.mm in Sources */,
 				13787CF31B12110C00400A4A /* HeadUpProgressViewController.swift in Sources */,
 				13787CF41B12110C00400A4A /* AdditionalDictionaryViewController.swift in Sources */,
-				13787CF51B12110C00400A4A /* DownloadDictionaryViewController.swift in Sources */,
+				13787CF51B12110C00400A4A /* DicitonaryURLViewController.swift in Sources */,
 				135181E61B12139000774954 /* DictionarySettings.swift in Sources */,
 				135182281B1224BA00774954 /* ValidateDictionary.swift in Sources */,
 				13787CF61B12110C00400A4A /* MainMenuViewController.swift in Sources */,
@@ -1154,6 +1161,7 @@
 				135181FE1B12139000774954 /* NumberFormatter.swift in Sources */,
 				135181F51B12139000774954 /* LoadLocalDictionary.swift in Sources */,
 				13787CF71B12110C00400A4A /* WebViewController.swift in Sources */,
+				13E86DCA1B49E5E100B327C4 /* SelectDictionaryViewController.swift in Sources */,
 				13787CF81B12110C00400A4A /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FlickSKK/AdditionalDictionaries.swift
+++ b/FlickSKK/AdditionalDictionaries.swift
@@ -1,0 +1,55 @@
+// 追加辞書の情報一覧を管理する
+//
+// 設定画面で表示したりする、有効な辞書一覧や追加できる辞書一覧を取得する。
+class AdditionalDictionaries {
+    typealias Entry = (title: String, url: String, path: String?)
+
+    private let defaultDictionaries : [Entry] = [
+        (title: "人名辞書",
+            url: "http://openlab.jp/skk/skk/dic/SKK-JISYO.jinmei",
+            path: nil),
+        (title: "郵便番号辞書",
+            url: "http://openlab.jp/skk/skk/dic/zipcode/SKK-JISYO.zipcode",
+            path: nil),
+        (title: "沖縄辞書",
+            url: "http://openlab.jp/skk/skk/dic/SKK-JISYO.okinawa",
+            path: nil),
+        (title: "絵文字辞書",
+            url: "https://raw.githubusercontent.com/uasi/skk-emoji-jisyo/master/SKK-JISYO.emoji.utf8",
+            path: nil),
+    ]
+
+    // すでに追加した辞書のファイル名
+    private lazy var dictionaryFiles =
+        SKKDictionary.additionalDictionaries().map { $0.lastPathComponent }
+
+    // 有効になった(追加した)辞書一覧の取得
+    func enabledDictionaries() -> [Entry] {
+        return dictionaryFiles.map { path in
+            self.dictionaryForPath(path).map {
+                self.copy($0, path: path)
+                } ?? (title: path, url: "", path: path)
+        }
+    }
+
+    // 有効にできる辞書一覧を取得する
+    func availableDictionaries() -> [Entry] {
+        return defaultDictionaries.filter { entry in
+            !contains(self.dictionaryFiles, entry.url.lastPathComponent)
+        }
+    }
+
+    private func dictionaryForPath(path : String) -> Entry? {
+        for entry in defaultDictionaries {
+            if entry.url.lastPathComponent == path.lastPathComponent {
+                return entry
+            }
+        }
+        return nil
+    }
+
+    private func copy(entry : Entry, path : String) -> Entry {
+        // XXX: 名前付きタプルのうち、一部だけを書き換える。そのうちシンタックスが搭載されると信じてる。
+        return (title: entry.title, url: entry.url, path: path)
+    }
+}

--- a/FlickSKK/DicitonaryURLViewController.swift
+++ b/FlickSKK/DicitonaryURLViewController.swift
@@ -1,21 +1,16 @@
 import UIKit
 
-// URL指定で追加辞書のダウンロードを行なうための画面。
-// ダウンロード処理自体は DownloadDictionary にまかせているので、画面表示だけを行なえばいい。
-//
-// プログレスバーでの進捗表示をしようかと思ったが、3G回線でもほぼ待ち時間なしでダウンロードできたので
-// とりあえずあとまわしにしている。
-class DownloadDictionaryViewController : SafeTableViewController, UITextFieldDelegate {
+// 追加辞書をダウンロードするURLを指定する画面。
+class DictionaryURLViewController : SafeTableViewController, UITextFieldDelegate {
     private let urlField = UITextField(frame: CGRectZero)
     private lazy var doneButton : UIBarButtonItem = UIBarButtonItem(
         title: NSLocalizedString("Download", comment:""),
         style: .Done, target:self, action: Selector("download"))
-    private let done : Void -> Void
+    private let done : String -> Void
 
-    init(url : String, done : Void -> Void) {
+    init(done : String -> Void) {
         self.done = done
         super.init(style: .Grouped)
-        urlField.text = url
         self.doneButton.enabled = canDownload()
         self.navigationItem.rightBarButtonItem = doneButton
     }
@@ -30,7 +25,6 @@ class DownloadDictionaryViewController : SafeTableViewController, UITextFieldDel
 
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return 1
-
     }
 
     override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -71,37 +65,8 @@ class DownloadDictionaryViewController : SafeTableViewController, UITextFieldDel
 
     @objc private func download() {
         if canDownload() {
-            let vc = HeadUpProgressViewController()
-            let action = DownloadDictionary(url: self.urlField.text)
-
-            var oldTitle : String? = nil
-            action.progress = { (title, progress) in
-                vc.text = title
-                vc.progress = progress
-            }
-            action.success = { info in
-                vc.close {
-                    self.alert(NSLocalizedString("DownloadComplete", comment:""),
-                        message: NSString(format: NSLocalizedString("%d okuri-ari %d okuri-nasi", comment:""), info.okuriAri(), info.okuriNasi()) as String) {
-                            self.navigationController?.popViewControllerAnimated(true)
-                            self.done()
-                    }
-                }
-            }
-            action.error = { (title, e) in
-                vc.close {
-                    self.alert(title, message: e?.localizedDescription ?? "")
-                }
-            }
-            action.call()
-            presentViewController(vc, animated: true, completion: nil)
+            self.navigationController?.popViewControllerAnimated(true)
+            self.done(self.urlField.text)
         }
-    }
-
-    // アラートメッセージを表示する
-    private func alert(title: String, message: String, completion: (() -> Void)? = nil) {
-        let ac = UIAlertController(title: title, message: message, preferredStyle: .Alert)
-        ac.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .Default, handler: { _ in completion?() }))
-        presentViewController(ac, animated: true, completion: nil)
     }
 }

--- a/FlickSKK/DicitonaryURLViewController.swift
+++ b/FlickSKK/DicitonaryURLViewController.swift
@@ -11,6 +11,7 @@ class DictionaryURLViewController : SafeTableViewController, UITextFieldDelegate
     init(done : String -> Void) {
         self.done = done
         super.init(style: .Grouped)
+        self.title = NSLocalizedString("Specify URL", comment: "")
         self.doneButton.enabled = canDownload()
         self.navigationItem.rightBarButtonItem = doneButton
     }

--- a/FlickSKK/DownloadDictionary.swift
+++ b/FlickSKK/DownloadDictionary.swift
@@ -45,7 +45,8 @@ class DownloadDictionary {
                 if let e = self.encodeToUTF8(downloadFile, dest: utf8File) {
                     self.error?(NSLocalizedString("EncodingError", comment:""), e)
                 } else {
-                    // メインスレッドはプログラスバーの更新を行なうので辞書の検証等は別スレッドで行なう。
+                    // メインスレッドはプログレスバーの更新を行なうので辞書の検証等は別スレッドで行なう。
+                    // FIXME: コールバックはメインスレッドにもどしたほうがいい?
                     async {
                         let dictionary = LoadLocalDictionary(path: utf8File)
 

--- a/FlickSKK/MainMenuViewController.swift
+++ b/FlickSKK/MainMenuViewController.swift
@@ -13,20 +13,12 @@ class MainMenuViewController: SafeTableViewController {
     lazy var sections : [(title: String?, rows: [row])] = {
         weak var weakSelf = self
         return [
-            (title: nil, rows: [self.item("Setup") {
-                weakSelf?.gotoSetup()
-            }]),
-            (title: nil, rows: [self.item("How to use") {
-                weakSelf?.gotoHowToUse()
-            }]),
-            // FIXME: 設定項目をなんか増やす
-            // (title: nil, rows: [(title: NSLocalizedString("Settings", comment: ""), action: { weakSelf?.gotoSettings(); return})]),
-            (title: nil, rows: [self.item("Additional Dictionary") {
-                weakSelf?.gotoAdditionalDictionary()
-            }]),
-            (title: nil, rows: [self.item("User Dictionary") {
-                weakSelf?.gotoUserDictionary()
-            }]),
+            (title: nil, rows: [
+                self.item("Setup") { weakSelf?.gotoSetup() },
+                self.item("How to use") { weakSelf?.gotoHowToUse() }]),
+            (title: nil, rows: [
+                self.item("User Dictionary") { weakSelf?.gotoUserDictionary() },
+                self.item("Additional Dictionary") { weakSelf?.gotoAdditionalDictionary() }]),
             (title: nil, rows: [self.item("Reset Learn Dictionary", accessoryType: .None) {
                 weakSelf?.reset(); return
             }]),

--- a/FlickSKK/SelectDictionaryViewController.swift
+++ b/FlickSKK/SelectDictionaryViewController.swift
@@ -10,6 +10,7 @@ class SelectDictionaryViewController: SafeTableViewController {
     init(done : Void -> Void) {
         self.done = done
         super.init(style: .Grouped)
+        self.title =  NSLocalizedString("Add New Dictionary", comment: "")
     }
 
     required init(coder aDecoder: NSCoder) {
@@ -23,7 +24,7 @@ class SelectDictionaryViewController: SafeTableViewController {
 
     func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch section {
-        case 0: return NSLocalizedString("Suggested Dictionary", comment: "")
+        case 0: return ""
         case 1: return NSLocalizedString("Other Dictionary", comment: "")
         default: fatalError("section > 1 has not been implemented")
         }

--- a/FlickSKK/SelectDictionaryViewController.swift
+++ b/FlickSKK/SelectDictionaryViewController.swift
@@ -1,0 +1,105 @@
+import UIKit
+
+// 追加できる辞書一覧を表示して、ダウンロードする辞書を選ばせる画面。
+// URLを直接指定することもある。
+class SelectDictionaryViewController: SafeTableViewController {
+    private let done : Void -> Void
+
+    private lazy var entries = AdditionalDictionaries().availableDictionaries()
+
+    init(done : Void -> Void) {
+        self.done = done
+        super.init(style: .Grouped)
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Table View
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 2 // entries + add
+    }
+
+    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch section {
+        case 0: return NSLocalizedString("Suggested Dictionary", comment: "")
+        case 1: return NSLocalizedString("Other Dictionary", comment: "")
+        default: fatalError("section > 1 has not been implemented")
+        }
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case 0: return self.entries.count
+        case 1: return 1
+        default: fatalError("section > 1 has not been implemented")
+        }
+    }
+
+    private let kCellID = "Cell"
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier(kCellID) as? UITableViewCell ?? UITableViewCell(style: .Default, reuseIdentifier: kCellID)
+
+        cell.selectionStyle = .None
+
+        switch indexPath.section {
+        case 0: cell.textLabel?.text = self.entries[indexPath.row].title
+        case 1:
+            cell.textLabel?.text = NSLocalizedString("Specify URL", comment: "")
+            cell.accessoryType = .DisclosureIndicator
+        default: ()
+        }
+
+        return cell
+    }
+
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        tableView.deselectRowAtIndexPath(indexPath, animated: true)
+
+        switch indexPath.section {
+        case 0:
+            self.download(self.entries[indexPath.row].url)
+        case 1:
+            self.navigationController?.pushViewController(DictionaryURLViewController(            done: { url in
+                    self.download(url)
+            }), animated: true)
+        default:
+            ()
+        }
+    }
+
+    // MARK: - Download
+    private func download(url : String) {
+        let vc = HeadUpProgressViewController()
+        let action = DownloadDictionary(url: url)
+
+        action.progress = { (title, progress) in
+            vc.text = title
+            vc.progress = progress
+        }
+        action.success = { info in
+            vc.close {
+                self.alert(NSLocalizedString("DownloadComplete", comment:""),
+                    message: NSString(format: NSLocalizedString("%d okuri-ari %d okuri-nasi", comment:""), info.okuriAri(), info.okuriNasi()) as String) {
+                        self.navigationController?.popViewControllerAnimated(true)
+                        self.done()
+                }
+            }
+        }
+        action.error = { (title, e) in
+            vc.close {
+                self.alert(title, message: e?.localizedDescription ?? "")
+            }
+        }
+        action.call()
+        presentViewController(vc, animated: true, completion: nil)
+    }
+
+    // アラートメッセージを表示する
+    private func alert(title: String, message: String, completion: (() -> Void)? = nil) {
+        let ac = UIAlertController(title: title, message: message, preferredStyle: .Alert)
+        ac.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .Default, handler: { _ in completion?() }))
+        presentViewController(ac, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
under :construction:

![ios simulator screen shot jul 6 2015 8 29 33 am](https://cloud.githubusercontent.com/assets/9650/8513949/0f93d31e-23bb-11e5-81bf-4dba3418cd26.png)

![ios simulator screen shot jul 6 2015 8 39 02 am](https://cloud.githubusercontent.com/assets/9650/8513950/14ee7940-23bb-11e5-9de7-9d28469630ef.png)

## TODO

 - [ ] エラー処理まわりが、ちゃんと動いてるか確認する
 - [ ] ライセンス表記どうする?
 - [ ] 推奨辞書という言葉をどうにかする
 - [ ] ヘッダとフッタをつける?
 - [ ] SKK openlab へのリンクをつける
 - [ ] SKK openlabが落ちてる?