### PR TITLE
Fix iOS 10 flick popup performance

### DIFF
--- a/FlickSKK/Info.plist
+++ b/FlickSKK/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/FlickSKKKeyboard/Info.plist
+++ b/FlickSKKKeyboard/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>3</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/FlickSKKKeyboard/KeyButton.swift
+++ b/FlickSKKKeyboard/KeyButton.swift
@@ -21,7 +21,7 @@ class KeyButton: UIView, UIGestureRecognizerDelegate {
                 let text = String(Array(s)[self.sequenceIndex ?? 0])
                 // FIXME: special ignore label
                 if(text != KanaFlickKey.ignoredSequence) {
-                    self.label.text = text
+// avoid iOS 10 layout performance issue: self.label.text = text
                 }
             }
         }

--- a/Memo/Info.plist
+++ b/Memo/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
workaround for #152 

iOS 10 GMが来る前に準備しておきます。
1.4.1から余計な変更が入らないように↓のような環境にしてビルドしてますが，古すぎてキツいかもです。

* rbenv local 2.2.3
* gem install cocoapods -v 0.37.2
* pod _0.37.2_ install
* Archive on Xcode 6.4

バージョン1.4.2はTestFlightで，主に3D Touchのために使っていたので，欠番とします。