### PR TITLE
サポートをiOS 13以上にする

### DIFF
--- a/Common/ThemeColor.swift
+++ b/Common/ThemeColor.swift
@@ -5,8 +5,7 @@ private struct ColorPair {
     var dark: UIColor
 
     var color: UIColor {
-        guard #available(iOS 13.0, iOSApplicationExtension 13.0, *) else { return light }
-        return .init(dynamicProvider: {
+        .init(dynamicProvider: {
             switch $0.userInterfaceStyle {
             case .light, .unspecified: return self.light
             case .dark: return self.dark

--- a/FlickSKK.xcodeproj/project.pbxproj
+++ b/FlickSKK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -843,8 +843,9 @@
 		13F610072102B31D00A27B6F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1000;
-				LastUpgradeCheck = 1410;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = codefirst;
 				TargetAttributes = {
 					13F6100E2102B31D00A27B6F = {
@@ -1285,7 +1286,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1344,7 +1345,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/FlickSKK.xcodeproj/xcshareddata/xcschemes/FlickSKK.xcscheme
+++ b/FlickSKK.xcodeproj/xcshareddata/xcschemes/FlickSKK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FlickSKK.xcodeproj/xcshareddata/xcschemes/FlickSKKKeyboard.xcscheme
+++ b/FlickSKK.xcodeproj/xcshareddata/xcschemes/FlickSKKKeyboard.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1430"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/FlickSKK.xcodeproj/xcshareddata/xcschemes/Memo.xcscheme
+++ b/FlickSKK.xcodeproj/xcshareddata/xcschemes/Memo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FlickSKK/HeadUpProgressViewController.swift
+++ b/FlickSKK/HeadUpProgressViewController.swift
@@ -47,15 +47,6 @@ class HeadUpProgressViewController: UIViewController {
         // 画面中央に表示する
         self.view.addConstraint(NSLayoutConstraint(item: progressView, attribute: .centerY, relatedBy: .equal, toItem: view, attribute: .centerY, multiplier: 1, constant: 0))
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        UIApplication.shared.isNetworkActivityIndicatorVisible = false
-    }
 
     fileprivate func updateProgress() {
         // メインスレッドで更新しないとプログレスバーが反映されない

--- a/FlickSKKKeyboard/ComposeModePresenter.swift
+++ b/FlickSKKKeyboard/ComposeModePresenter.swift
@@ -11,7 +11,7 @@ class ComposeModePresenter {
             return candidates[index].kanji
         case .wordRegister(kana: _, okuri: let okuri, composeText: let text, composeMode: let m):
             let nested = markedText(m[0])
-            return text + (okuri ?? "") + (nested ?? "")
+            return text + (nested ?? "")
         }
     }
 

--- a/FlickSKKKeyboard/ComposeModePresenter.swift
+++ b/FlickSKKKeyboard/ComposeModePresenter.swift
@@ -9,7 +9,7 @@ class ComposeModePresenter {
             return kana
         case .kanjiCompose(kana: _, okuri: _, candidates: let candidates, index: let index):
             return candidates[index].kanji
-        case .wordRegister(kana: _, okuri: let okuri, composeText: let text, composeMode: let m):
+        case .wordRegister(kana: _, okuri: _, composeText: let text, composeMode: let m):
             let nested = markedText(m[0])
             return text + (nested ?? "")
         }

--- a/FlickSKKKeyboard/ComposeModePresenter.swift
+++ b/FlickSKKKeyboard/ComposeModePresenter.swift
@@ -1,22 +1,5 @@
 // ComposeModeを表示する
 class ComposeModePresenter {
-    /// (iOS 13未満用(markedTextなしで全ての情報を返す)) 表示用文字列(▽あああ、みたいなやつ)
-    func toString(_ composeMode : ComposeMode) -> String {
-        switch composeMode {
-        case .directInput:
-            return ""
-        case .kanaCompose(kana: let kana, candidates: _):
-            return "▽\(kana)"
-        case .kanjiCompose(kana: let kana, okuri: let okuri, candidates: _, index: _):
-            let text = kana + (okuri.map({ str in "*" + str }) ?? "")
-            return "▼\(text)"
-        case .wordRegister(kana : let kana, okuri : let okuri, composeText : let text, composeMode : let m):
-            let prefix = kana + (okuri.map({ str in "*" + str }) ?? "")
-            let nested = toString(m[0])
-            return "[登録:\(prefix)]\(text)\(nested)"
-        }
-    }
-
     /// 入力先のアプリにマーク付きテキストで表示する未確定文字列
     func markedText(_ composeMode : ComposeMode) -> String? {
         switch composeMode {

--- a/FlickSKKKeyboard/KeyboardViewController.swift
+++ b/FlickSKKKeyboard/KeyboardViewController.swift
@@ -14,7 +14,7 @@ class KeyboardViewController: UIInputViewController, SKKDelegate {
     lazy var heightConstraint : NSLayoutConstraint = NSLayoutConstraint(item: self.view!, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 0.0, constant: 216)
 
     let keypadAndControlsView = UIView()
-    let loadingProgressView = UIActivityIndicatorView(style: .gray)
+    let loadingProgressView = UIActivityIndicatorView(style: .medium)
 
     lazy var sessionView : SessionView = SessionView(engine: self.engine)
 
@@ -402,14 +402,10 @@ class KeyboardViewController: UIInputViewController, SKKDelegate {
     }
 
     func composeText(_ text: String?, markedText: String?, legacyStyleText: String) {
-        if #available(iOS 13.0, iOSApplicationExtension 13.0, *) {
-            sessionView.composeText = text
+        sessionView.composeText = text
 
-            let markedText = markedText ?? ""
-            inputProxy.setMarkedText(markedText, selectedRange: NSRange(location: (markedText as NSString).length, length: 0))
-        } else {
-            sessionView.composeText = legacyStyleText
-        }
+        let markedText = markedText ?? ""
+        inputProxy.setMarkedText(markedText, selectedRange: NSRange(location: (markedText as NSString).length, length: 0))
 
         updateSpaceButtonLabel()
     }

--- a/FlickSKKKeyboard/KeyboardViewController.swift
+++ b/FlickSKKKeyboard/KeyboardViewController.swift
@@ -401,7 +401,7 @@ class KeyboardViewController: UIInputViewController, SKKDelegate {
         self.engine.handle(.toggleUpperLower(beforeText: self.inputProxy.documentContextBeforeInput ?? ""))
     }
 
-    func composeText(_ text: String?, markedText: String?, legacyStyleText: String) {
+    func composeText(_ text: String?, markedText: String?) {
         sessionView.composeText = text
 
         let markedText = markedText ?? ""

--- a/FlickSKKKeyboard/SKKDelegate.swift
+++ b/FlickSKKKeyboard/SKKDelegate.swift
@@ -16,7 +16,7 @@ protocol SKKDelegate : AnyObject {
     func deleteBackward()
 
     // 未確定文字の表示
-    func composeText(_ text :String?, markedText: String?, legacyStyleText: String)
+    func composeText(_ text :String?, markedText: String?)
 
     // 入力モードの変更
     func changeInputMode(_ inputMode : SKKInputMode)

--- a/FlickSKKKeyboard/SKKEngine.swift
+++ b/FlickSKKKeyboard/SKKEngine.swift
@@ -22,7 +22,7 @@ class SKKEngine {
         composeMode = keyHandler.handle(keyEvent, composeMode: composeMode)
 
         // 表示を更新
-        delegate?.composeText(presenter.composeText(composeMode), markedText: presenter.markedText(composeMode), legacyStyleText: presenter.toString(composeMode))
+        delegate?.composeText(presenter.composeText(composeMode), markedText: presenter.markedText(composeMode))
 
         // 候補表示
         delegate?.showCandidates(candidates()?.candidates)

--- a/FlickSKKTests/ComposeModePresenterSpec.swift
+++ b/FlickSKKTests/ComposeModePresenterSpec.swift
@@ -28,7 +28,7 @@ class ComposeModePresenterSpec : QuickSpec {
             it("word register mode(direct)") {
                 let m = ComposeMode.wordRegister(kana: "ろうたけ", okuri: "る", composeText: "あああ", composeMode: [.directInput])
                 expect(target.composeText(m)).to(equal("[登録:ろうたけ*る]あああ"))
-                expect(target.markedText(m)).to(equal("ああある"))
+                expect(target.markedText(m)).to(equal("あああ"))
             }
             it("word register mode(kana compose)") {
                 let m = ComposeMode.wordRegister(kana: "ほんき", okuri: nil, composeText: "あ",

--- a/FlickSKKTests/ComposeModePresenterSpec.swift
+++ b/FlickSKKTests/ComposeModePresenterSpec.swift
@@ -8,27 +8,33 @@ class ComposeModePresenterSpec : QuickSpec {
         let candidates : [Candidate] = [ .exact(kanji: "本気"), .partial(kanji: "マジ", kana: "まじ") ]
         describe("toString") {
             it("direct input") {
-                expect(target.toString(.directInput)).to(equal(""))
+                expect(target.composeText(.directInput)).to(beNil())
+                expect(target.markedText(.directInput)).to(beNil())
             }
             it("kana compose mode") {
-                expect(target.toString(.kanaCompose(kana: "こんにちは", candidates: candidates))).to(equal("▽こんにちは"))
+                expect(target.composeText(.kanaCompose(kana: "こんにちは", candidates: candidates))).to(equal("▽"))
+                expect(target.markedText(.kanaCompose(kana: "こんにちは", candidates: candidates))).to(equal("こんにちは"))
             }
             it("kanji compose mode") {
                 let m = ComposeMode.kanjiCompose(kana: "ほんき", okuri: .none, candidates: candidates, index: 0)
-                expect(target.toString(m)).to(equal("▼ほんき"))
+                expect(target.composeText(m)).to(equal("▼"))
+                expect(target.markedText(m)).to(equal("本気"))
             }
             it("word register mode(direct)") {
                 let m = ComposeMode.wordRegister(kana: "ほんき", okuri: nil, composeText: "あああ", composeMode: [.directInput])
-                expect(target.toString(m)).to(equal("[登録:ほんき]あああ"))
+                expect(target.composeText(m)).to(equal("[登録:ほんき]あああ"))
+                expect(target.markedText(m)).to(equal("あああ"))
             }
             it("word register mode(direct)") {
                 let m = ComposeMode.wordRegister(kana: "ろうたけ", okuri: "る", composeText: "あああ", composeMode: [.directInput])
-                expect(target.toString(m)).to(equal("[登録:ろうたけ*る]あああ"))
+                expect(target.composeText(m)).to(equal("[登録:ろうたけ*る]あああ"))
+                expect(target.markedText(m)).to(equal("ああある"))
             }
             it("word register mode(kana compose)") {
                 let m = ComposeMode.wordRegister(kana: "ほんき", okuri: nil, composeText: "あ",
                     composeMode: [.kanaCompose(kana: "い", candidates: [])])
-                expect(target.toString(m)).to(equal("[登録:ほんき]あ▽い"))
+                expect(target.composeText(m)).to(equal("[登録:ほんき]あ▽"))
+                expect(target.markedText(m)).to(equal("あい"))
             }
         }
 

--- a/FlickSKKTests/MockDelegate.swift
+++ b/FlickSKKTests/MockDelegate.swift
@@ -10,7 +10,7 @@ class MockDelegate : SKKDelegate {
         self.insertedText = self.insertedText.butLast()
     }
 
-    func composeText(_ text :String?, markedText: String?, legacyStyleText: String) {
+    func composeText(_ text :String?, markedText: String?) {
     }
 
     func changeInputMode(_ inputMode: SKKInputMode) {

--- a/FlickSKKTests/SKKEngineSpec.swift
+++ b/FlickSKKTests/SKKEngineSpec.swift
@@ -13,10 +13,9 @@ class SKKEngineSpec : QuickSpec, SKKDelegate {
     // delegate
     func insertText(_ text : String) { self.insertedText += text }
     func deleteBackward() {}
-    func composeText(_ text : String?, markedText: String?, legacyStyleText: String) {
+    func composeText(_ text : String?, markedText: String?) {
         self.currentComposeText = text
         self.currentMarkedText = markedText
-        self.legacyStyleText = legacyStyleText
     }
     func changeInputMode(_ inputMode: SKKInputMode) {}
     func showCandidates(_ candidates: [Candidate]?) { self.candidates = candidates }
@@ -25,7 +24,6 @@ class SKKEngineSpec : QuickSpec, SKKDelegate {
     var insertedText = ""
     var currentComposeText: String?
     var currentMarkedText: String?
-    var legacyStyleText = ""
     var candidates: [Candidate]? = nil
 
     override func spec() {
@@ -52,11 +50,9 @@ class SKKEngineSpec : QuickSpec, SKKDelegate {
                 it("convert kanji") {
                     engine.handle(.char(kana: "や", shift: true))
                     engine.handle(.char(kana: "ま", shift: false))
-                    expect(self.legacyStyleText).to(equal("▽やま"))
                     expect(self.currentComposeText).to(equal("▽"))
                     expect(self.currentMarkedText).to(equal("やま"))
                     engine.handle(.space)
-                    expect(self.legacyStyleText).to(equal("▼やま"))
                     expect(self.currentComposeText).to(equal("▼"))
                     expect(self.currentMarkedText).to(equal("山"))
                     engine.handle(.enter)
@@ -73,11 +69,9 @@ class SKKEngineSpec : QuickSpec, SKKDelegate {
                         engine.handle(.char(kana: "か", shift: true))
                         engine.handle(.char(kana: "ん", shift: false))
                         engine.handle(.char(kana: "し", shift: true))
-                        expect(self.legacyStyleText).to(equal("▼かん*し"))
                         expect(self.currentComposeText).to(equal("▼"))
                         expect(self.currentMarkedText).to(equal("関し"))
                         engine.handle(.toggleDakuten(beforeText: ""))
-                        expect(self.legacyStyleText).to(equal("▼かん*じ"))
                         expect(self.currentComposeText).to(equal("▼"))
                         expect(self.currentMarkedText).to(equal("感じ"))
                         engine.handle(.enter)

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 use_frameworks!
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - AppGroup (1.0.0)
   - FootlessParser (0.5.2)
-  - Nimble (10.0.0)
+  - Nimble (12.0.0)
   - NorthLayout (5.2.0):
     - FootlessParser (~> 0.4)
-  - Quick (5.0.1)
-  - "※ikemen (0.7.0)"
+  - Quick (6.1.0)
+  - "※ikemen (0.8.0)"
 
 DEPENDENCIES:
   - AppGroup (from `Pods/CocoaPodsAppGroup/AppGroup.podspec.json`)
@@ -29,11 +29,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppGroup: ba0c3626371b5b0f23815f7ae68d14f1061df19f
   FootlessParser: 521916d592fa6cba06cfca6f4b5d4f5a2d49175a
-  Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
+  Nimble: 02a4990866e51868303a466970cd1c81bb84a192
   NorthLayout: 308a58a8f7d96f316e6399ff6432f8769321bbdf
-  Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  "※ikemen": db03a47c165f9889af8260758087b49f6cdeee2f
+  Quick: 6676ffb409bf04abba2ff23902af2407bfc6ac90
+  "※ikemen": dd846bad2317b0ea51e5c7dd8e565108fa40d528
 
-PODFILE CHECKSUM: dbddf1ec57f185bdde0a3a9a5194000e5438b59b
+PODFILE CHECKSUM: 88486acd6e5763ee4c6b6072f3bca52217dae98a
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
iOS 13以上ならsetMarkedTextが使えるのでバージョン分岐とlegacyStyleTextを削除